### PR TITLE
View management

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,17 @@
+/*
+ * Web-pane
+ * Copyright (C) 2025  Marcin Forseti Paździora
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */

--- a/README.md
+++ b/README.md
@@ -1,19 +1,28 @@
 # web-pane
-Web-pane is a cross-platform desktop application that allows you to open web pages in "panes" - a kind of always-on-top panes.
+Web-pane is a cross-platform desktop application that allows you to open web pages in "panes" - a kind of always-on-top windows.
 
-It is intended to provide an ability to browse a web page and have it right at your fingertips, while working with other applications. Such a pair could be a chat window and a web browser, a documentation and a code editor or Wikipedia and a text editor. 
+It is intended to provide an ability to browse a web page and have it right at your fingertips, while working with other applications. Use cases include a chat window and a web browser, a documentation and a code editor or Wikipedia and a text editor. 
 
-You can have up to two panes (right now, it will be more flexible in the future), and each of them can host many web pages. In each pane, only one page is visible at a time and you can switch between them either by keyboard shortcuts, running a command or by clicking on the dock or desktop activators (if you did setup them). Running it by issuing a command allows for flexible integrations, like using a dock or a panel to open the web page.
+The app uses simple, always-on-top windows (**panes**) to open web pages. You can have multiple panes opened, and each of them can host many web pages. In each pane, only one page is visible at a time and you can switch between them either by keyboard shortcuts, running a command or by clicking on the dock or desktop activators (if you did setup them). Running it by issuing a command allows for flexible integrations, like using a dock or a panel to open the web page.
 
 ## Installation
 The application uses the Electron framework. Thus, it is available for Linux, Windows and MacOS.
 To obtain the application, you can either:
 - download the latest release from the [releases page](https://github.com/forsetius/web-pane/releases)
-- clone the repository and build the application yourself
+- clone the [repository](https://github.com/forsetius/web-pane) and build the application yourself
 
-For now (v0.8.0), the application is tested only on Linux. Tests on Windows are in progress.
+For now (v1.1.0), the application is tested only on Linux. Tests on Windows are in progress.
 
 You need Node.js installed to build the application. In the future, the application will be dockerized so developing it will be easier.
+
+### Releases
+
+Each release consists of multiple types of installers and files you can download to get using the application. These are:
+- **Linux DEB package** - for Linux distributions like Debian, Ubuntu or Linux Mint. You need root access but once installed, every user can run it like a system command
+- **Linux AppImage** - for Linux system, it's an executable you can run standalone, without root access. You'll need to rename it to something practical (like `web-pane`) and copy it to a directory on your `PATH` (like `~/.local/bin`) so that it could be run from any directory
+- **Windows NSIS installer** - it's Windows installer package that will install the application on your Windows machine. Administrator rights will be required and the system will probably complain as the app is not certified.
+- **Windows Portable** - it's Windows executable that can be run standalone, without proper instalation on your machine. No administration rights necessary, just put it in a directory it can be found and rename it to something practical (like `web-pane`)
+- **macOS ZIP** - the only form of distribution I can make for Mac
 
 ### Instalation from the repository
 To install the application from the repository, you need to:
@@ -22,26 +31,83 @@ To install the application from the repository, you need to:
 3. run `web-pane`
 4. From now on you can run the application with `web-pane` from any directory
 
-## Basic invocation
+## Invocation
 Web-pane can be started in various ways depending on your integrations. Still, in every case it is started by a command.
 
-The simplest invocation is:
-> `web-pane --url <url>` - opens the webapp in the right (default) window
+The simplest (even if not the most convenient) invocation is:
+> `web-pane` - opens an empty pane, ready to open your first page
 
-You can also specify the target window:
-> `web-pane --url <url> --target left` - opens the webapp in the left window
+You can also open the pane with a web page loaded:
+> `web-pane --url <url>` - opens the web page in the default pane
 
-Internally, the application creates an ID for each webapp out of the domain portion of its URL. 
-That means that if you have two webapps with the same domain, like: 
+You can specify the target pane too:
+> `web-pane --url <url> --target <pane>` - opens the webapp in the target pane
+
+Internally, the application uses an ID for each webapp. By default, the ID is simply the domain portion of its URL. So, if we use `--url https://www.facebook.com/messages/t/123456789` option, the ID would be `www.facebook.com`. That means that if you have two webapps with the same domain, like: 
 - `https://www.facebook.com` for Facebook
 - `https://www.facebook.com/messages/t/123456789` for Facebook Messenger
   they will be treated as the same webapp and overwrite one another. To overcome this, you can add an `--id` argument:
 > `web-pane --url <url> --id <id>` - opens the webapp with given ID
 
-The command issued first time will open the web page in a pane. Later invocations will either make it visible (if another web page is visible in the pane it will be replaced with this one) or will minimize the pane if it is already visible.
+So, the full invocation is:
+> `web-pane --url <url> --id <id> --target <pane>`
 
-## Example setup for Linux: Web-pane + Plank
-These instructions are for Linux Mint but would work for Debian-based distros (like Ubuntu) as well.
+The first `web-pane` command launches the application. Subsequent commands run their task and exit, leaving only the single running instance. 
+If `web-pane` is run with the same `--id` option the second time, it will either make the page visible (if it was hidded behind some other page or its pane was minimized) or minimize the pane (if the page was already visible).
+
+## Usage
+
+You can open a web page from `Page > Open page` menu command or with `Ctrl+O`. You need to provide an URL and the command will allow you to open a page in current pane, some other existing pane (if you created some already) or in a new one. If you want it opened in a new pane, you need to name it - use some short name like "work", "docs" or "chat", it's used for internal pane tracking.
+
+You can open multiple pages in one pane but only one is visible at the time. To switch to another one use `Ctrl+Tab` (next) or `Ctrl+Shift+Tab` (previous). You'll see a switcher with icons of opened pages and each `Ctrl+Tab` or `Ctrl+Shift+Tab` will switch to following/preceding one. You can close a web page with `Page > Close page` menu command or with `F4`.
+
+You can interact with the page as in normal browser except for context menu and history. There is no context menu unless the page defines a custom one. The example would be Google Maps that allow you to use several custom actions once you press right mouse button. As of history, you can browse back with `Alt+←` and forward with `Alt+→`. There are also menu commands for that.
+
+You can change the dimensions of the pane and move it around (on Linux you can choose to have title-less panes and move them with `Alt` pressed) and the changes will be saved for later. A new pane can be opened with `Pane > New pane` menu command or with `Ctrl+N`. You can also move a web page to another pane (existing or a new one) with `Page > Move page` menu command or with `Ctrl+M`. To minimize a pane use a `Pane > Minimize` or `Alt+↓`. Note that if you chose to hide `web-pane`'s windows from the system's window list it's best to define system-wide keyboard shortcut to bring it back - use `web-pane` command to restore all the panes or `web-pane --target <pane>` to restore only a given one.
+
+## Integrations
+
+Invoking the app with command line's `web-pane ...` would be very tedious. So, it's better to integrate it with your system. It can be done in several ways.
+
+### Activators
+A much more convenient way to launch the application is through shortcuts (on Windows: `.lnk` files, on macOS: aliases, on Linux: `.desktop` files).
+Create a desktop shortcut and edit it so it runs `web-pane --url <url>` or any of the variants shown above. 
+
+On Linux, example `.desktop` file should look like this:
+```
+[Desktop Entry]
+# Replace the values below with your own
+Name=ChatGPT
+Exec=web-pane --url https://www.chatgpt.com
+Icon=window-new
+
+# Paste the following lines, do not change
+Type=Application
+StartupWMClass=web-panes
+StartupNotify=false
+Terminal=false
+```
+
+Click on the activator to open the webapp in the pane. The pane will stay atop the other panes, allowing you to peek its contents even while you are using other applications. If you click on the activator again, the pane will minimize. To bring it again, click its activator yet again.
+
+### Batch files
+You could make entire layouts of panes with web pages already opened with batch files/scripts. Just create a file with a series of `web-pane ...` commands and make it executable. For example on Linux you could have a web-dev layout with 2 panes defined like this:
+
+```sh
+#!/bin/sh
+web-pane --url https://chatgpt.com
+web-pane --url https://docs.nestjs.com
+web-pane --url https://nodejs.org/docs/latest/api/
+web-pane --url https://www.facebook.com/messages/t/123456789 --target messages
+web-pane --url https://web.whatsapp.com/ --target messages
+```
+
+Of course you can create an activator with such a script and run it with one click.
+
+### Docks
+
+Example setup for Linux Mint: Web-pane + two Plank docks. Should work for Debian-based distros (like Ubuntu) as well.
+
 1. Install Plank:
     > `sudo apt install plank`
 2. Create two instances of Plank's docks in Autostart:
@@ -52,45 +118,31 @@ These instructions are for Linux Mint but would work for Debian-based distros (l
 3. Create the `.desktop` files for the webapps you want to see in the panes. For left pane use command:
     > `web-pane --url <url> --target left`
 
-    For right pane use the same command but substitute "left" with "right" (or omit the `--target` argument)
-    
-    Example `.desktop` file should look like this:
-    ```
-    [Desktop Entry]
-    # Replace the values below with your own
-    Name=ChatGPT
-    Exec=web-pane https://www.chatgpt.com
-    Icon=window-new
-   
-    # Paste the following lines, do not change
-    Type=Application
-    StartupWMClass=web-panes
-    StartupNotify=false
-    Terminal=false
-    ```
+    For right pane use the same command but omit the `--target` argument.
+4. Drag the `.desktop` files to the proper Plank's dock
+5. In the "Keyboard" section of the System Settings switch to "Shortcuts" tab and add some global shortcuts, for example:
+    - `Alt+Up` with command: `web-pane` to open or bring back the panes when minimized
+    - `Ctrl+Shift+PgDn` with command: `bash -c 'web-pane --url "$(xclip -o -selection clipboard)"'` to open to previously copied URL in the main pane. You may need to install `xclip` package with `sudo apt install xclip` to use this shortcut.
 
-4. Move the `.desktop` files to the proper Plank's dock
-5. In the "Keyboard" section of the System settings switch to "Shortcuts" tab and add some global shortcuts, for example:
-    - `Alt+Up` with command: `web-pane https://chatgpt.com` to open or bring back the ChatGPT pane even if it is not yet started or is minimized
-    - `Ctrl+Shift+PgDn` with command: `bash -c 'web-pane --url "$(xclip -o -selection clipboard)"'` to open to previously copied URL in the right pane. You may need to install `xclip` package with `sudo apt install xclip` to use this shortcut.
+Provided you have the application installed and you added Plank to the autostart, it will start automatically and present defined webapp activators. 
 
-Provided you have the application installed and you added Plank to the autostart, it will start automatically and present defined webapp activators. Click on the activator to open the webapp in the pane. The pane will stay atop the other panes, allowing you to peek its contents even while you are using other applications. If you click on the activator again, the pane will minimize - it's still there, just hidden from the window list. To bring it again, click its activator yet again
-
-## Usage
-
-When you click on some other activator, its webapp will replace the previous one in its pane. You can switch between the webapps by clicking on the activators or by using the keyboard shortcuts: `Ctrl+Tab` and `Ctrl+Shift+Tab`. There are other shortcuts available:
+## Keyboard shortcuts
+- `Ctrl+N` - open a new pane
+- `Ctrl+O` - open a new web page in current pane
+- `Ctrl+M` - move the current web page to a different pane (already existing or a new one)
+- `Ctrl+Shift+Tab` - switch to the previous webapp
+- `Ctrl+Tab` - switch to the next webapp
 - `Alt+Down` - minimize the pane (click on any activator to unminimize it)
-- `Ctrl+F4` - close the webapp
+- `F4` - close the current web page
+- `Ctrl+F4` - close the current pane
 - `Alt+F4` - quit the application
+- `Alt+Left` - go back in the webapp
+- `Alt+Right` - go forward in the webapp
 - `Ctrl+R` - reload the webapp
 - `Ctrl+Shift+R` - force-reload the webapp (without cache)
 - `Ctrl+Shift+=` - zoom in
 - `Ctrl+Shift+-` - zoom out
 - `Ctrl+0` - reset zoom
-- `Alt+Left` - go back in the webapp
-- `Alt+Right` - go forward in the webapp
-- `Ctrl+Shift+Tab` - switch to the previous webapp
-- `Ctrl+Tab` - switch to the next webapp
 - `F10` - preferences
 
-You can also move the panes by holding `Alt` and dragging them with the mouse.
+On Linux you can also move the panes by holding `Alt` and dragging them with the mouse.

--- a/assets/appWindows.css
+++ b/assets/appWindows.css
@@ -1,0 +1,51 @@
+:root { --divider-color: rgba(0,0,0,.1); }
+[data-bs-theme="dark"] { --divider-color: rgba(255,255,255,.12); }
+
+html, body { margin: 0; }
+body {
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans",
+    "Liberation Sans", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    overflow: hidden;
+}
+
+.window { background: var(--bs-body-bg); color: var(--bs-body-color); }
+.window__header, .window__main, .window__footer { padding: 12px 16px; }
+.window__header {
+    display: flex; align-items: center; gap: 12px;
+    border-bottom: 1px solid var(--divider-color);
+}
+.window__title {
+    margin: 0;
+    font-size: clamp(1.5rem, 1.2rem + 1.2vw, 2rem); /* większy tytuł */
+    font-weight: 400; line-height: 1.2;
+    flex: 1 1 auto; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.window__close { flex: 0 0 auto; }
+
+.window__main { border-bottom: 1px solid var(--divider-color); /* overflow visible, by rosło */ }
+
+.window__footer {
+    display: flex; align-items: center; justify-content: flex-end; gap: .5rem;
+    padding-right: 12px;
+}
+
+.form-grid .form-row {
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    align-items: center;
+    column-gap: 1rem; row-gap: .5rem;
+    margin-bottom: .75rem;
+}
+.form-grid .form-row .form-label { margin-bottom: 0; text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+.more-toggle { margin: .25rem 0 .75rem; }
+.more-section { margin-top: .5rem; padding-top: .5rem; border-top: 1px dashed var(--divider-color); }
+
+.pane-choice .form-check { margin-bottom: .5rem; }
+
+@media (max-width: 380px) {
+    .form-grid .form-row { grid-template-columns: 1fr; align-items: start; }
+}
+
+.hint { font-size: .875rem; color: var(--bs-tertiary-color); padding-left: 1.5rem; font-style: italic}
+.form-switch .form-check-input { width: 2.5em; height: 1.25em; }

--- a/assets/motif.js
+++ b/assets/motif.js
@@ -1,0 +1,15 @@
+(function () {
+  const mql = window.matchMedia('(prefers-color-scheme: dark)');
+  const apply = () => {
+    document.documentElement.setAttribute(
+      'data-bs-theme',
+      mql.matches ? 'dark' : 'light',
+    );
+  };
+  apply();
+  if (typeof mql.addEventListener === 'function') {
+    mql.addEventListener('change', apply);
+  } else if (typeof mql.addListener === 'function') {
+    mql.addListener(apply);
+  }
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "web-pane",
       "version": "1.0.2",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "bootstrap": "^5.3.8",
         "deepmerge-ts": "^7.1.5",
@@ -14,24 +15,24 @@
         "tsyringe": "^4.10.0",
         "yargs": "^18.0.0",
         "yoctocolors": "^2.1.2",
-        "zod": "^4.1.8"
+        "zod": "^4.1.11"
       },
       "devDependencies": {
-        "@eslint/js": "^9.35.0",
+        "@eslint/js": "^9.36.0",
         "@tsconfig/node24": "^24.0.1",
-        "@tsconfig/strictest": "^2.0.5",
-        "@types/node": "^24.3.1",
+        "@tsconfig/strictest": "^2.0.6",
+        "@types/node": "^24.5.2",
         "@types/yargs": "^17.0.33",
-        "electron": "^38.1.0",
+        "electron": "^38.1.2",
         "electron-builder": "^26.0.20",
         "electron-updater": "^6.6.8",
-        "eslint": "^9.35.0",
+        "eslint": "^9.36.0",
         "prettier": "^3.6.2",
         "rimraf": "^6.0.1",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.9.2",
-        "typescript-eslint": "^8.43.0"
+        "typescript-eslint": "^8.44.1"
       },
       "engines": {
         "node": ">=24.5.0"
@@ -746,9 +747,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
-      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.36.0.tgz",
+      "integrity": "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1238,9 +1239,9 @@
       "license": "MIT"
     },
     "node_modules/@tsconfig/strictest": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@tsconfig/strictest/-/strictest-2.0.5.tgz",
-      "integrity": "sha512-ec4tjL2Rr0pkZ5hww65c+EEPYwxOi4Ryv+0MtjeaSQRJyq322Q27eOQiFbuNgw2hpL4hB1/W/HBGk3VKS43osg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@tsconfig/strictest/-/strictest-2.0.6.tgz",
+      "integrity": "sha512-tPOhmDhIUcDjvpDDYyiUdssP84Eqm7n5KxJe5J3/g+s6xoDIPAf+SIn06dhw7VkhxIvLOnhDDrX7tsqMHNEhDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1316,13 +1317,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.3.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.3.tgz",
-      "integrity": "sha512-GKBNHjoNw3Kra1Qg5UXttsY5kiWMEfoHq2TmXb+b1rcm6N7B3wTrFYIf/oSZ1xNQ+hVVijgLkiDZh7jRRsh+Gw==",
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.10.0"
+        "undici-types": "~7.12.0"
       }
     },
     "node_modules/@types/plist": {
@@ -1384,17 +1385,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.43.0.tgz",
-      "integrity": "sha512-8tg+gt7ENL7KewsKMKDHXR1vm8tt9eMxjJBYINf6swonlWgkYn5NwyIgXpbbDxTNU5DgpDFfj95prcTq2clIQQ==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.1.tgz",
+      "integrity": "sha512-molgphGqOBT7t4YKCSkbasmu1tb1MgrZ2szGzHbclF7PNmOkSTQVHy+2jXOSnxvR3+Xe1yySHFZoqMpz3TfQsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.43.0",
-        "@typescript-eslint/type-utils": "8.43.0",
-        "@typescript-eslint/utils": "8.43.0",
-        "@typescript-eslint/visitor-keys": "8.43.0",
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/type-utils": "8.44.1",
+        "@typescript-eslint/utils": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -1408,7 +1409,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.43.0",
+        "@typescript-eslint/parser": "^8.44.1",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -1424,16 +1425,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.43.0.tgz",
-      "integrity": "sha512-B7RIQiTsCBBmY+yW4+ILd6mF5h1FUwJsVvpqkrgpszYifetQ2Ke+Z4u6aZh0CblkUGIdR59iYVyXqqZGkZ3aBw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.1.tgz",
+      "integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.43.0",
-        "@typescript-eslint/types": "8.43.0",
-        "@typescript-eslint/typescript-estree": "8.43.0",
-        "@typescript-eslint/visitor-keys": "8.43.0",
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1449,14 +1450,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.43.0.tgz",
-      "integrity": "sha512-htB/+D/BIGoNTQYffZw4uM4NzzuolCoaA/BusuSIcC8YjmBYQioew5VUZAYdAETPjeed0hqCaW7EHg+Robq8uw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.1.tgz",
+      "integrity": "sha512-ycSa60eGg8GWAkVsKV4E6Nz33h+HjTXbsDT4FILyL8Obk5/mx4tbvCNsLf9zret3ipSumAOG89UcCs/KRaKYrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.43.0",
-        "@typescript-eslint/types": "^8.43.0",
+        "@typescript-eslint/tsconfig-utils": "^8.44.1",
+        "@typescript-eslint/types": "^8.44.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1471,14 +1472,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.43.0.tgz",
-      "integrity": "sha512-daSWlQ87ZhsjrbMLvpuuMAt3y4ba57AuvadcR7f3nl8eS3BjRc8L9VLxFLk92RL5xdXOg6IQ+qKjjqNEimGuAg==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.1.tgz",
+      "integrity": "sha512-NdhWHgmynpSvyhchGLXh+w12OMT308Gm25JoRIyTZqEbApiBiQHD/8xgb6LqCWCFcxFtWwaVdFsLPQI3jvhywg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.43.0",
-        "@typescript-eslint/visitor-keys": "8.43.0"
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1489,9 +1490,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.43.0.tgz",
-      "integrity": "sha512-ALC2prjZcj2YqqL5X/bwWQmHA2em6/94GcbB/KKu5SX3EBDOsqztmmX1kMkvAJHzxk7TazKzJfFiEIagNV3qEA==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.1.tgz",
+      "integrity": "sha512-B5OyACouEjuIvof3o86lRMvyDsFwZm+4fBOqFHccIctYgBjqR3qT39FBYGN87khcgf0ExpdCBeGKpKRhSFTjKQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1506,15 +1507,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.43.0.tgz",
-      "integrity": "sha512-qaH1uLBpBuBBuRf8c1mLJ6swOfzCXryhKND04Igr4pckzSEW9JX5Aw9AgW00kwfjWJF0kk0ps9ExKTfvXfw4Qg==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.1.tgz",
+      "integrity": "sha512-KdEerZqHWXsRNKjF9NYswNISnFzXfXNDfPxoTh7tqohU/PRIbwTmsjGK6V9/RTYWau7NZvfo52lgVk+sJh0K3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.43.0",
-        "@typescript-eslint/typescript-estree": "8.43.0",
-        "@typescript-eslint/utils": "8.43.0",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1",
+        "@typescript-eslint/utils": "8.44.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -1531,9 +1532,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.43.0.tgz",
-      "integrity": "sha512-vQ2FZaxJpydjSZJKiSW/LJsabFFvV7KgLC5DiLhkBcykhQj8iK9BOaDmQt74nnKdLvceM5xmhaTF+pLekrxEkw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.1.tgz",
+      "integrity": "sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1545,16 +1546,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.43.0.tgz",
-      "integrity": "sha512-7Vv6zlAhPb+cvEpP06WXXy/ZByph9iL6BQRBDj4kmBsW98AqEeQHlj/13X+sZOrKSo9/rNKH4Ul4f6EICREFdw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.1.tgz",
+      "integrity": "sha512-qnQJ+mVa7szevdEyvfItbO5Vo+GfZ4/GZWWDRRLjrxYPkhM+6zYB2vRYwCsoJLzqFCdZT4mEqyJoyzkunsZ96A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.43.0",
-        "@typescript-eslint/tsconfig-utils": "8.43.0",
-        "@typescript-eslint/types": "8.43.0",
-        "@typescript-eslint/visitor-keys": "8.43.0",
+        "@typescript-eslint/project-service": "8.44.1",
+        "@typescript-eslint/tsconfig-utils": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1613,16 +1614,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.43.0.tgz",
-      "integrity": "sha512-S1/tEmkUeeswxd0GGcnwuVQPFWo8NzZTOMxCvw8BX7OMxnNae+i8Tm7REQen/SwUIPoPqfKn7EaZ+YLpiB3k9g==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.1.tgz",
+      "integrity": "sha512-DpX5Fp6edTlocMCwA+mHY8Mra+pPjRZ0TfHkXI8QFelIKcbADQz1LUPNtzOFUriBB2UYqw4Pi9+xV4w9ZczHFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.43.0",
-        "@typescript-eslint/types": "8.43.0",
-        "@typescript-eslint/typescript-estree": "8.43.0"
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1637,13 +1638,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.43.0.tgz",
-      "integrity": "sha512-T+S1KqRD4sg/bHfLwrpF/K3gQLBM1n7Rp7OjjikjTEssI2YJzQpi5WXoynOaQ93ERIuq3O8RBTOUYDKszUCEHw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.1.tgz",
+      "integrity": "sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.43.0",
+        "@typescript-eslint/types": "8.44.1",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -3052,9 +3053,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "38.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-38.1.0.tgz",
-      "integrity": "sha512-ypA8GF8RU4HD5pA1sa0/2U8k+92EPP2c7pX+3XbgB760F7OmqrFXtYkOilVw6HfV4+lk88XxqigmsUKTACQYoQ==",
+      "version": "38.1.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-38.1.2.tgz",
+      "integrity": "sha512-WXUcN3W8h8NTTZViA3KNX0rV2YBU0X0mEUM3ubupXTDY4QtIN7tmiqYVOKSKpR2LckTmBWGuEeY4D6xVoffwKQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3556,9 +3557,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
-      "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
+      "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3568,7 +3569,7 @@
         "@eslint/config-helpers": "^0.3.1",
         "@eslint/core": "^0.15.2",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.35.0",
+        "@eslint/js": "9.36.0",
         "@eslint/plugin-kit": "^0.3.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -6670,16 +6671,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.43.0.tgz",
-      "integrity": "sha512-FyRGJKUGvcFekRRcBKFBlAhnp4Ng8rhe8tuvvkR9OiU0gfd4vyvTRQHEckO6VDlH57jbeUQem2IpqPq9kLJH+w==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.44.1.tgz",
+      "integrity": "sha512-0ws8uWGrUVTjEeN2OM4K1pLKHK/4NiNP/vz6ns+LjT/6sqpaYzIVFajZb1fj/IDwpsrrHb3Jy0Qm5u9CPcKaeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.43.0",
-        "@typescript-eslint/parser": "8.43.0",
-        "@typescript-eslint/typescript-estree": "8.43.0",
-        "@typescript-eslint/utils": "8.43.0"
+        "@typescript-eslint/eslint-plugin": "8.44.1",
+        "@typescript-eslint/parser": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1",
+        "@typescript-eslint/utils": "8.44.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6694,9 +6695,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7018,9 +7019,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
-      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,20 @@
 {
   "name": "web-pane",
   "version": "1.0.2",
-  "description": "Pane utility windows for Plank",
+  "description": "Pane utility windows",
   "author": {
     "name": "Marcin Forseti Paździora",
     "email": "marcin.pazdziora@forseti.pl",
     "url": "https://forseti.pl"
+  },
+  "license": "GPL-3.0-or-later",
+  "homepage": "https://github.com/forsetius/web-pane",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/forsetius/web-pane.git"
+  },
+  "bugs": {
+    "url": "https://github.com/forsetius/web-pane/issues"
   },
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "web-pane",
   "version": "1.0.2",
-  "description": "Pane utility windows",
+  "description": "Always-on-top windows that can host multiple web pages and switch between them.",
   "author": {
     "name": "Marcin Forseti Paździora",
     "email": "marcin.pazdziora@forseti.pl",
-    "url": "https://forseti.pl"
+    "url": "https://forseti.pl?lang=en"
   },
   "license": "GPL-3.0-or-later",
-  "homepage": "https://github.com/forsetius/web-pane",
+  "homepage": "https://forseti.pl/pages/en/web-pane.html",
   "repository": {
     "type": "git",
     "url": "https://github.com/forsetius/web-pane.git"
@@ -44,23 +44,23 @@
     "tsyringe": "^4.10.0",
     "yargs": "^18.0.0",
     "yoctocolors": "^2.1.2",
-    "zod": "^4.1.8"
+    "zod": "^4.1.11"
   },
   "devDependencies": {
-    "@eslint/js": "^9.35.0",
+    "@eslint/js": "^9.36.0",
     "@tsconfig/node24": "^24.0.1",
-    "@tsconfig/strictest": "^2.0.5",
-    "@types/node": "^24.3.1",
+    "@tsconfig/strictest": "^2.0.6",
+    "@types/node": "^24.5.2",
     "@types/yargs": "^17.0.33",
-    "electron": "^38.1.0",
+    "electron": "^38.1.2",
     "electron-builder": "^26.0.20",
     "electron-updater": "^6.6.8",
-    "eslint": "^9.35.0",
+    "eslint": "^9.36.0",
     "prettier": "^3.6.2",
     "rimraf": "^6.0.1",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.9.2",
-    "typescript-eslint": "^8.43.0"
+    "typescript-eslint": "^8.44.1"
   }
 }

--- a/src/configDefaults.ts
+++ b/src/configDefaults.ts
@@ -2,7 +2,6 @@ import { Lang } from './types/Lang.js';
 import type { AppConfig } from './types/AppConfig.js';
 
 export const configDefaults: AppConfig = {
-  lang: Lang.PL,
   panes: {
     main: {
       visible: false,
@@ -14,6 +13,7 @@ export const configDefaults: AppConfig = {
     },
   },
   ui: {
+    lang: Lang.PL,
     showWindowFrame: true,
     showAppMenu: true,
     showInWindowList: true,

--- a/src/domain/App.ts
+++ b/src/domain/App.ts
@@ -9,6 +9,8 @@ import { parseCli } from '../parseCli.js';
 import { quitWithFatalError } from '../utils/error.js';
 import { OpenViewWindow } from './appWindows/OpenViewWindow.js';
 import { TranslationService } from './TranslationService.js';
+import { NewPaneWindow } from './appWindows/NewPaneWindow.js';
+import { MoveViewWindow } from './appWindows/MoveViewWindow.js';
 // import { AboutWindow } from './appWindows/AboutWindow.js';
 // import { LocalPageWindow } from './appWindows/LocalPageWindow.js';
 
@@ -23,6 +25,8 @@ export class App {
   public readonly appWindows: AppWindows = {
     // about: undefined,
     // localPage: undefined,
+    moveView: undefined,
+    newPane: undefined,
     openView: undefined,
     preferences: undefined,
   };
@@ -80,6 +84,8 @@ export class App {
       },
     );
 
+    this.appWindows.moveView = new MoveViewWindow(this);
+    this.appWindows.newPane = new NewPaneWindow(this);
     this.appWindows.openView = new OpenViewWindow(this);
 
     this._appMenu = new AppMenu(this);
@@ -117,24 +123,13 @@ export class App {
 
     this.appMenu.build(lang);
   }
-
-  public toggleFocusedDevTools(detach = true): void {
-    const activeView = this.appWindows.preferences?.window;
-    const wc = activeView?.webContents;
-
-    if (!wc) return;
-
-    if (wc.isDevToolsOpened()) {
-      wc.closeDevTools();
-    } else {
-      wc.openDevTools({ mode: detach ? 'detach' : 'right' });
-    }
-  }
 }
 
 interface AppWindows {
   // about: AboutWindow | undefined;
   // localPage: LocalPageWindow | undefined;
+  moveView: MoveViewWindow | undefined;
+  newPane: NewPaneWindow | undefined;
   openView: OpenViewWindow | undefined;
   preferences: PreferencesWindow | undefined;
 }

--- a/src/domain/App.ts
+++ b/src/domain/App.ts
@@ -12,6 +12,7 @@ import { TranslationService } from './TranslationService.js';
 import { NewPaneWindow } from './appWindows/NewPaneWindow.js';
 import { MoveViewWindow } from './appWindows/MoveViewWindow.js';
 import { AboutWindow } from './appWindows/AboutWindow.js';
+import { BaseDialogWindow } from './appWindows/BaseDialogWindow.js';
 
 @singleton()
 export class App {
@@ -116,13 +117,12 @@ export class App {
   }
 
   public changeLanguage(lang: Lang) {
-    this.configService.save({ ui: { lang } });
-
     this.appMenu.build(lang);
+    Object.values(this.appWindows).forEach((dialog: BaseDialogWindow | undefined) => {
+      if (!dialog?.window || (dialog.window.isDestroyed() || dialog.window.webContents.isDestroyed())) return;
 
-    for (const dialog of Object.values(this.appWindows)) {
-      dialog?.refresh();
-    }
+      dialog.window.webContents.send('i18n:language-changed', lang);
+    });
   }
 }
 

--- a/src/domain/App.ts
+++ b/src/domain/App.ts
@@ -86,9 +86,6 @@ export class App {
     this.appWindows.openView = new OpenViewWindow(this);
 
     this._appMenu = new AppMenu(this);
-    electronApp.on('before-quit', () =>
-      this.appWindows.preferences?.setQuitting(true),
-    );
   }
 
   public async handleInvocation(argv: string[]) {

--- a/src/domain/App.ts
+++ b/src/domain/App.ts
@@ -11,8 +11,7 @@ import { OpenViewWindow } from './appWindows/OpenViewWindow.js';
 import { TranslationService } from './TranslationService.js';
 import { NewPaneWindow } from './appWindows/NewPaneWindow.js';
 import { MoveViewWindow } from './appWindows/MoveViewWindow.js';
-// import { AboutWindow } from './appWindows/AboutWindow.js';
-// import { LocalPageWindow } from './appWindows/LocalPageWindow.js';
+import { AboutWindow } from './appWindows/AboutWindow.js';
 
 @singleton()
 export class App {
@@ -23,8 +22,7 @@ export class App {
   public configService!: ConfigService;
   public translationService!: TranslationService;
   public readonly appWindows: AppWindows = {
-    // about: undefined,
-    // localPage: undefined,
+    about: undefined,
     moveView: undefined,
     newPane: undefined,
     openView: undefined,
@@ -73,8 +71,7 @@ export class App {
   public init() {
     this.translationService.registerIpc();
 
-    // this.appWindows.about = new AboutWindow();
-    // this.appWindows.localPage = new LocalPageWindow();
+    this.appWindows.about = new AboutWindow();
     this.appWindows.preferences = new PreferencesWindow(
       (ui) => {
         this.panes.applyUi(ui);
@@ -126,8 +123,7 @@ export class App {
 }
 
 interface AppWindows {
-  // about: AboutWindow | undefined;
-  // localPage: LocalPageWindow | undefined;
+  about: AboutWindow | undefined;
   moveView: MoveViewWindow | undefined;
   newPane: NewPaneWindow | undefined;
   openView: OpenViewWindow | undefined;

--- a/src/domain/App.ts
+++ b/src/domain/App.ts
@@ -79,13 +79,16 @@ export class App {
       async () => {
         await this.panes.recreateWindows();
       },
+      (lang) => {
+        this.changeLanguage(lang);
+      },
     );
 
-    this.appWindows.moveView = new MoveViewWindow(this);
-    this.appWindows.newPane = new NewPaneWindow(this);
-    this.appWindows.openView = new OpenViewWindow(this);
+    this.appWindows.moveView = new MoveViewWindow(this.panes);
+    this.appWindows.newPane = new NewPaneWindow(this.panes);
+    this.appWindows.openView = new OpenViewWindow(this.panes);
 
-    this._appMenu = new AppMenu(this);
+    this._appMenu = new AppMenu(this.panes, this.appWindows);
   }
 
   public async handleInvocation(argv: string[]) {
@@ -113,13 +116,17 @@ export class App {
   }
 
   public changeLanguage(lang: Lang) {
-    this.configService.save({ lang });
+    this.configService.save({ ui: { lang } });
 
     this.appMenu.build(lang);
+
+    for (const dialog of Object.values(this.appWindows)) {
+      dialog?.refresh();
+    }
   }
 }
 
-interface AppWindows {
+export interface AppWindows {
   about: AboutWindow | undefined;
   moveView: MoveViewWindow | undefined;
   newPane: NewPaneWindow | undefined;

--- a/src/domain/AppMenu.ts
+++ b/src/domain/AppMenu.ts
@@ -17,21 +17,24 @@ export class AppMenu {
     const t = this.translationService;
     const template: MenuItemConstructorOptions[] = [
       {
-        label: t.get(lang, 'menu.app'),
+        label: t.get(lang, 'menu.pane'),
         submenu: [
           {
-            label: t.get(lang, 'menu.minimize'),
-            accelerator: 'Alt+Down',
+            label: t.get(lang, 'menu.newPane'),
+            accelerator: process.platform === 'darwin' ? 'Cmd+N' : 'Ctrl+N',
             click: () => {
-              this.minimize();
+              this.newPane();
             },
           },
           {
-            label: t.get(lang, 'menu.closeView'),
-            accelerator: process.platform === 'darwin' ? 'Cmd+Shift+W' : 'F4',
+            label: t.get(lang, 'menu.switchPane'),
+            accelerator:
+              process.platform === 'darwin'
+                ? 'Cmd+Shift+Tab'
+                : 'Ctrl+Shift+Tab',
             click: (_m, window) => {
               if (!window) return;
-              this.closeView(window as BrowserWindow);
+              this.openView();
             },
           },
           {
@@ -44,9 +47,77 @@ export class AppMenu {
           },
           { type: 'separator' },
           {
+            label: t.get(lang, 'menu.preferences'),
+            accelerator: 'F10',
+            click: () => {
+              void this.showPreferencesWindow();
+            },
+          },
+          { type: 'separator' },
+          {
+            label: 'Minimize',
+            accelerator: 'Alt+Down',
+            click: () => {
+              this.minimize();
+            },
+          },
+          {
             role: 'quit',
             label: t.get(lang, 'menu.quit'),
             accelerator: 'Alt+F4',
+          },
+        ],
+      },
+      {
+        label: t.get(lang, 'menu.page'),
+        submenu: [
+          {
+            label: t.get(lang, 'menu.openView'),
+            accelerator: process.platform === 'darwin' ? 'Cmd+O' : 'Ctrl+O',
+            click: (_m, window) => {
+              if (!window) return;
+              this.openView();
+            },
+          },
+          {
+            label: t.get(lang, 'menu.switchView'),
+            accelerator: process.platform === 'darwin' ? 'Cmd+Tab' : 'Ctrl+Tab',
+            click: (_m, window) => {
+              if (!window) return;
+              this.openView();
+            },
+          },
+          {
+            label: t.get(lang, 'menu.moveViewToPane'),
+            accelerator: 'F6',
+            click: (_m, window) => {
+              if (!window) return;
+              this.openView();
+            },
+          },
+          { type: 'separator' },
+          {
+            label: t.get(lang, 'menu.backward'),
+            accelerator: process.platform === 'darwin' ? 'Cmd+[' : 'Alt+Left',
+            click: () => {
+              this.goBack();
+            },
+          },
+          {
+            label: t.get(lang, 'menu.forward'),
+            accelerator: process.platform === 'darwin' ? 'Cmd+]' : 'Alt+Right',
+            click: () => {
+              this.goForward();
+            },
+          },
+          { type: 'separator' },
+          {
+            label: t.get(lang, 'menu.closeView'),
+            accelerator: process.platform === 'darwin' ? 'Cmd+Shift+W' : 'F4',
+            click: (_m, window) => {
+              if (!window) return;
+              this.closeView(window as BrowserWindow);
+            },
           },
         ],
       },
@@ -70,11 +141,6 @@ export class AppMenu {
           },
           { type: 'separator' },
           {
-            role: 'resetZoom',
-            label: t.get(lang, 'menu.resetZoom'),
-            accelerator: process.platform === 'darwin' ? 'Cmd+0' : 'Ctrl+0',
-          },
-          {
             role: 'zoomIn',
             label: t.get(lang, 'menu.zoomIn'),
             accelerator:
@@ -85,13 +151,10 @@ export class AppMenu {
             label: t.get(lang, 'menu.zoomOut'),
             accelerator: process.platform === 'darwin' ? 'Cmd+-' : 'Ctrl+-',
           },
-          { type: 'separator' },
           {
-            label: t.get(lang, 'menu.preferences'),
-            accelerator: 'F10',
-            click: () => {
-              void this.showPreferencesWindow();
-            },
+            role: 'resetZoom',
+            label: t.get(lang, 'menu.resetZoom'),
+            accelerator: process.platform === 'darwin' ? 'Cmd+0' : 'Ctrl+0',
           },
           { type: 'separator' },
           {
@@ -104,42 +167,19 @@ export class AppMenu {
         ],
       },
       {
-        label: t.get(lang, 'menu.navigation'),
+        label: t.get(lang, 'menu.help'),
         submenu: [
           {
-            label: t.get(lang, 'menu.backward'),
-            accelerator: process.platform === 'darwin' ? 'Cmd+[' : 'Alt+Left',
-            click: () => {
-              this.goBack();
-            },
+            label: t.get(lang, 'menu.instruction'),
+            // click: () => {
+            //   void this.showLocalPageWindow(`readme-${lang}.html`);
+            // },
           },
           {
-            label: t.get(lang, 'menu.forward'),
-            accelerator: process.platform === 'darwin' ? 'Cmd+]' : 'Alt+Right',
-            click: () => {
-              this.goForward();
-            },
-          },
-        ],
-      },
-      {
-        label: t.get(lang, 'menu.language'),
-        submenu: [
-          {
-            label: t.get(lang, 'menu.polish'),
-            type: 'radio',
-            checked: this.configService.get('lang') === Lang.PL,
-            click: () => {
-              this.changeLanguage(Lang.PL);
-            },
-          },
-          {
-            label: t.get(lang, 'menu.english'),
-            type: 'radio',
-            checked: this.configService.get('lang') === Lang.EN,
-            click: () => {
-              this.changeLanguage(Lang.EN);
-            },
+            label: t.get(lang, 'menu.about'),
+            // click: () => {
+            //   void this.showAboutWindow();
+            // },
           },
         ],
       },
@@ -148,8 +188,14 @@ export class AppMenu {
     Menu.setApplicationMenu(Menu.buildFromTemplate(template));
   }
 
-  private changeLanguage(lang: Lang) {
-    this.app.changeLanguage(lang);
+  private closePane(window: Electron.BaseWindow) {
+    window.close();
+  }
+
+  private closeView(window: Electron.BrowserWindow) {
+    const pane = this.app.panes.getById(window.id);
+    if (!pane) return;
+    pane.closeView();
   }
 
   private goBack() {
@@ -175,6 +221,14 @@ export class AppMenu {
     }
   }
 
+  private newPane() {
+    this.app.panes.createWindow('left'); // TODO - make this configurable
+  }
+
+  private openView() {
+    void this.app.appWindows.openView?.show();
+  }
+
   private reload() {
     const pane = this.app.panes.getActive();
     if (!pane) return;
@@ -189,17 +243,15 @@ export class AppMenu {
     pane.getCurrentView()?.webContents.reloadIgnoringCache();
   }
 
+  // private async showAboutWindow() {
+  //   await this.app.appWindows.about?.show();
+  // }
+  //
+  // private async showLocalPageWindow(page: string) {
+  //   await this.app.appWindows.localPage?.show(`../../assets/${page}`);
+  // }
+
   private async showPreferencesWindow() {
     await this.app.appWindows.preferences?.show();
-  }
-
-  private closePane(window: Electron.BaseWindow) {
-    window.close();
-  }
-
-  private closeView(window: Electron.BrowserWindow) {
-    const pane = this.app.panes.getById(window.id);
-    if (!pane) return;
-    pane.closeView();
   }
 }

--- a/src/domain/AppMenu.ts
+++ b/src/domain/AppMenu.ts
@@ -1,4 +1,8 @@
-import { BrowserWindow, Menu, MenuItemConstructorOptions } from 'electron';
+import {
+  BrowserWindow,
+  Menu,
+  MenuItemConstructorOptions,
+} from 'electron';
 import { App } from './App.js';
 import { Lang } from '../types/Lang.js';
 import { container } from 'tsyringe';
@@ -140,18 +144,14 @@ export class AppMenu {
       {
         label: t.get(lang, 'menu.help'),
         submenu: [
-          {
-            label: t.get(lang, 'menu.instruction'),
-            // click: () => {
-            //   void this.showLocalPageWindow(`readme-${lang}.html`);
-            // },
-          },
-          {
-            label: t.get(lang, 'menu.about'),
-            // click: () => {
-            //   void this.showAboutWindow();
-            // },
-          },
+          process.platform === 'darwin'
+            ? { role: 'about' }
+            : {
+              label: t.get(lang, 'menu.about'),
+              click: () => {
+                this.showAboutWindow();
+              },
+            },
         ],
       },
     ];
@@ -218,13 +218,9 @@ export class AppMenu {
     pane.getCurrentView()?.webContents.reloadIgnoringCache();
   }
 
-  // private async showAboutWindow() {
-  //   await this.app.appWindows.about?.show();
-  // }
-  //
-  // private async showLocalPageWindow(page: string) {
-  //   await this.app.appWindows.localPage?.show(`../../assets/${page}`);
-  // }
+  private async showAboutWindow() {
+    await this.app.appWindows.about?.show();
+  }
 
   private async showPreferencesWindow() {
     await this.app.appWindows.preferences?.show();

--- a/src/domain/AppMenu.ts
+++ b/src/domain/AppMenu.ts
@@ -27,17 +27,6 @@ export class AppMenu {
             },
           },
           {
-            label: t.get(lang, 'menu.switchPane'),
-            accelerator:
-              process.platform === 'darwin'
-                ? 'Cmd+Shift+Tab'
-                : 'Ctrl+Shift+Tab',
-            click: (_m, window) => {
-              if (!window) return;
-              this.openView();
-            },
-          },
-          {
             label: t.get(lang, 'menu.closePane'),
             accelerator: process.platform === 'darwin' ? 'Cmd+W' : 'Ctrl+F4',
             click: (_m, window) => {
@@ -74,25 +63,15 @@ export class AppMenu {
           {
             label: t.get(lang, 'menu.openView'),
             accelerator: process.platform === 'darwin' ? 'Cmd+O' : 'Ctrl+O',
-            click: (_m, window) => {
-              if (!window) return;
-              this.openView();
-            },
-          },
-          {
-            label: t.get(lang, 'menu.switchView'),
-            accelerator: process.platform === 'darwin' ? 'Cmd+Tab' : 'Ctrl+Tab',
-            click: (_m, window) => {
-              if (!window) return;
+            click: () => {
               this.openView();
             },
           },
           {
             label: t.get(lang, 'menu.moveViewToPane'),
-            accelerator: 'F6',
-            click: (_m, window) => {
-              if (!window) return;
-              this.openView();
+            accelerator: process.platform === 'darwin' ? 'Cmd+M' : 'Ctrl+M',
+            click: () => {
+              this.moveView();
             },
           },
           { type: 'separator' },
@@ -156,14 +135,6 @@ export class AppMenu {
             label: t.get(lang, 'menu.resetZoom'),
             accelerator: process.platform === 'darwin' ? 'Cmd+0' : 'Ctrl+0',
           },
-          { type: 'separator' },
-          {
-            label: 'DevTools',
-            accelerator: 'F12',
-            click: () => {
-              this.app.toggleFocusedDevTools(true);
-            },
-          },
         ],
       },
       {
@@ -199,21 +170,21 @@ export class AppMenu {
   }
 
   private goBack() {
-    const viewHistory = this.app.panes.getActive()?.getCurrentView()
+    const viewHistory = this.app.panes.getCurrent()?.getCurrentView()
       ?.webContents.navigationHistory;
 
     if (viewHistory?.canGoBack()) viewHistory.goBack();
   }
 
   private goForward() {
-    const viewHistory = this.app.panes.getActive()?.getCurrentView()
+    const viewHistory = this.app.panes.getCurrent()?.getCurrentView()
       ?.webContents.navigationHistory;
 
     if (viewHistory?.canGoForward()) viewHistory.goForward();
   }
 
   private minimize() {
-    const pane = this.app.panes.getActive();
+    const pane = this.app.panes.getCurrent();
     if (!pane) return;
 
     if (!pane.window.isMinimized()) {
@@ -221,8 +192,12 @@ export class AppMenu {
     }
   }
 
+  private moveView() {
+    void this.app.appWindows.moveView?.show();
+  }
+
   private newPane() {
-    this.app.panes.createWindow('left'); // TODO - make this configurable
+    void this.app.appWindows.newPane?.show();
   }
 
   private openView() {
@@ -230,14 +205,14 @@ export class AppMenu {
   }
 
   private reload() {
-    const pane = this.app.panes.getActive();
+    const pane = this.app.panes.getCurrent();
     if (!pane) return;
 
     pane.getCurrentView()?.webContents.reload();
   }
 
   private reloadUncached() {
-    const pane = this.app.panes.getActive();
+    const pane = this.app.panes.getCurrent();
     if (!pane) return;
 
     pane.getCurrentView()?.webContents.reloadIgnoringCache();

--- a/src/domain/AppMenu.ts
+++ b/src/domain/AppMenu.ts
@@ -3,18 +3,19 @@ import {
   Menu,
   MenuItemConstructorOptions,
 } from 'electron';
-import { App } from './App.js';
+import { AppWindows } from './App.js';
 import { Lang } from '../types/Lang.js';
 import { container } from 'tsyringe';
 import { TranslationService } from './TranslationService.js';
 import { ConfigService } from './ConfigService.js';
+import { PanePool } from './PanePool.js';
 
 export class AppMenu {
   private readonly configService = container.resolve(ConfigService);
   private readonly translationService = container.resolve(TranslationService);
 
-  public constructor(private readonly app: App) {
-    this.build(this.configService.get('lang'));
+  public constructor(private readonly panes: PanePool, private readonly appWindows: AppWindows) {
+    this.build(this.configService.get('ui.lang'));
   }
 
   public build(lang: Lang) {
@@ -164,27 +165,27 @@ export class AppMenu {
   }
 
   private closeView(window: Electron.BrowserWindow) {
-    const pane = this.app.panes.getById(window.id);
+    const pane = this.panes.getById(window.id);
     if (!pane) return;
     pane.closeView();
   }
 
   private goBack() {
-    const viewHistory = this.app.panes.getCurrent()?.getCurrentView()
+    const viewHistory = this.panes.getCurrent()?.getCurrentView()
       ?.webContents.navigationHistory;
 
     if (viewHistory?.canGoBack()) viewHistory.goBack();
   }
 
   private goForward() {
-    const viewHistory = this.app.panes.getCurrent()?.getCurrentView()
+    const viewHistory = this.panes.getCurrent()?.getCurrentView()
       ?.webContents.navigationHistory;
 
     if (viewHistory?.canGoForward()) viewHistory.goForward();
   }
 
   private minimize() {
-    const pane = this.app.panes.getCurrent();
+    const pane = this.panes.getCurrent();
     if (!pane) return;
 
     if (!pane.window.isMinimized()) {
@@ -193,36 +194,36 @@ export class AppMenu {
   }
 
   private moveView() {
-    void this.app.appWindows.moveView?.show();
+    void this.appWindows.moveView?.show();
   }
 
   private newPane() {
-    void this.app.appWindows.newPane?.show();
+    void this.appWindows.newPane?.show();
   }
 
   private openView() {
-    void this.app.appWindows.openView?.show();
+    void this.appWindows.openView?.show();
   }
 
   private reload() {
-    const pane = this.app.panes.getCurrent();
+    const pane = this.panes.getCurrent();
     if (!pane) return;
 
     pane.getCurrentView()?.webContents.reload();
   }
 
   private reloadUncached() {
-    const pane = this.app.panes.getCurrent();
+    const pane = this.panes.getCurrent();
     if (!pane) return;
 
     pane.getCurrentView()?.webContents.reloadIgnoringCache();
   }
 
   private async showAboutWindow() {
-    await this.app.appWindows.about?.show();
+    await this.appWindows.about?.show();
   }
 
   private async showPreferencesWindow() {
-    await this.app.appWindows.preferences?.show();
+    await this.appWindows.preferences?.show();
   }
 }

--- a/src/domain/PanePool.ts
+++ b/src/domain/PanePool.ts
@@ -85,13 +85,13 @@ export class PanePool {
       this._currentPaneId = target;
     });
 
-    const appWindow = new Pane(target, window);
+    const pane = new Pane(target, window);
     this.configService.save({
       panes: { [target]: { visible: true } },
     });
-    this.pool.set(target, appWindow);
+    this.pool.set(target, pane);
 
-    return appWindow;
+    return pane;
   }
 
   private persistWindowGeometry(target: string) {

--- a/src/domain/TranslationService.ts
+++ b/src/domain/TranslationService.ts
@@ -63,7 +63,7 @@ export class TranslationService {
     ipcMain.handle(
       'i18n:t',
       (_e, key: CT.DotPath<TranslationStrings>, lang?: Lang) => {
-        const language = lang ?? this.configService.get('lang');
+        const language = lang ?? this.configService.get('ui.lang');
         this.assertLang(language);
 
         return this.get(language, key);
@@ -72,7 +72,7 @@ export class TranslationService {
 
     ipcMain.removeHandler('i18n:bundle');
     ipcMain.handle('i18n:bundle', (_e, lang?: Lang) => {
-      const language = lang ?? this.configService.get('lang');
+      const language = lang ?? this.configService.get('ui.lang');
       this.assertLang(language);
 
       return this.store[language];

--- a/src/domain/appWindows/AboutWindow.ts
+++ b/src/domain/appWindows/AboutWindow.ts
@@ -1,5 +1,5 @@
 import { createRequire } from "node:module";
-import { ipcMain } from "electron";
+import { ipcMain, shell } from "electron";
 import { z } from "zod";
 import { BaseDialogWindow } from "./BaseDialogWindow.js";
 
@@ -34,6 +34,10 @@ export class AboutWindow extends BaseDialogWindow {
 
             return this.appInfo;
         });
+        ipcMain.on('about:open-external', (_event, url: string) => {
+            void shell.openExternal(url);
+        });
+
     }
 
     private getInfo(): AboutInfo {

--- a/src/domain/appWindows/AboutWindow.ts
+++ b/src/domain/appWindows/AboutWindow.ts
@@ -1,0 +1,68 @@
+import { createRequire } from "node:module";
+import { ipcMain } from "electron";
+import { z } from "zod";
+import { BaseDialogWindow } from "./BaseDialogWindow.js";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../../../package.json");
+
+const manifestSchema = z.object({
+    name: z.string().min(1),
+    version: z.string().min(1),
+    license: z.string().min(1),
+    homepage: z.url(),
+    author: z.object({
+        name: z.string().min(1),
+        url: z.url(),
+    }),
+    repository: z.url(),
+    bugs: z.url(),
+});
+
+export class AboutWindow extends BaseDialogWindow {
+    protected preloader = 'aboutPreload.cjs';
+    protected htmlContent = 'about.html';
+    private appInfo: AboutInfo | undefined = undefined;
+
+    protected registerIpc(): void {
+        if (ipcMain.listenerCount('about:get-info') > 0) return;
+
+        ipcMain.handle('about:get-info', () => {
+            if (!this.appInfo) {
+                this.appInfo = this.getInfo();
+            }
+
+            return this.appInfo;
+        });
+    }
+
+    private getInfo(): AboutInfo {
+        const info = {
+            name: packageJson?.name,
+            version: packageJson?.version,
+            author: {
+                name: packageJson?.author?.name,
+                url: packageJson?.author?.url,
+            },
+            license: packageJson?.license,
+            homepage: packageJson?.homepage,
+            repository: packageJson?.repository?.url,
+            bugs: packageJson?.bugs?.url,
+        };
+
+        return manifestSchema.parse(info);
+    }
+}
+
+export interface AboutInfo {
+    name: string;
+    version: string;
+    author: {
+        name: string;
+        url: string;
+    };
+    license: string;
+    homepage: string;
+    repository: string;
+    bugs: string;
+}

--- a/src/domain/appWindows/BaseDialogWindow.ts
+++ b/src/domain/appWindows/BaseDialogWindow.ts
@@ -1,0 +1,124 @@
+import { BrowserWindow, screen } from 'electron';
+import { join } from 'node:path';
+
+export abstract class BaseDialogWindow {
+  public window?: BrowserWindow | undefined;
+  protected abstract preloader: string;
+  protected abstract htmlContent: string;
+  protected nodeIntegration = false;
+  protected isQuitting = false;
+
+  public setQuitting(flag: boolean) {
+    this.isQuitting = flag;
+  }
+
+  public async show(): Promise<void> {
+    if (!this.window || this.window.isDestroyed()) {
+      await this.createWindow();
+    }
+
+    this.sendShowSignal();
+    this.window!.show();
+    this.window!.focus();
+  }
+
+  protected sendShowSignal(): void {
+    const wc = this.window!.webContents;
+
+    if (wc.isLoadingMainFrame()) {
+      wc.once('did-finish-load', () => {
+        wc.send('dialog:show');
+      });
+    } else {
+      wc.send('dialog:show');
+    }
+  }
+
+  protected async createWindow(): Promise<void> {
+    const window = new BrowserWindow({
+      width: 400,
+      height: 200,
+      resizable: false,
+      roundedCorners: true,
+      useContentSize: true,
+      minimizable: false,
+      maximizable: false,
+      alwaysOnTop: true,
+      autoHideMenuBar: true,
+      modal: true,
+      show: false,
+      frame: false,
+      type: 'utility',
+      titleBarStyle: 'hidden',
+      webPreferences: {
+        contextIsolation: true,
+        enablePreferredSizeMode: true,
+        nodeIntegration: this.nodeIntegration,
+        preload: join(import.meta.dirname, `../../preload/${this.preloader}`),
+        sandbox: false,
+        zoomFactor: 1,
+      },
+    });
+
+    window.webContents.on(
+      'preferred-size-changed',
+      (_ev, preferred: Electron.Size) => {
+        void this.fitTo(window, preferred.height);
+      },
+    );
+
+    window.webContents.once('did-finish-load', () => {
+      try {
+        void this.fitTo(window);
+      } finally {
+        window.show();
+      }
+    });
+
+    window.on('close', (e) => {
+      if (this.isQuitting) return;
+
+      e.preventDefault();
+      this.window?.hide();
+    });
+
+    window.on('closed', () => {
+      this.window = undefined;
+    });
+
+    await window.loadFile(
+      join(import.meta.dirname, `../../renderer/${this.htmlContent}`),
+    );
+
+    this.window = window;
+  }
+
+  protected abstract registerIpc(): void;
+
+  protected async fitTo(
+    window: BrowserWindow,
+    desiredHeight?: number,
+    desiredWidth?: number,
+  ): Promise<void> {
+    const height =
+      desiredHeight ??
+      ((await window.webContents.executeJavaScript(
+        'Math.ceil(document.documentElement.scrollHeight)',
+      )) as number);
+    const width =
+      desiredWidth ??
+      ((await window.webContents.executeJavaScript(
+        'Math.ceil(document.documentElement.scrollWidth)',
+      )) as number);
+    if (window.isDestroyed()) return;
+
+    const { workAreaSize } = screen.getDisplayMatching(window.getBounds());
+    const MARGIN = 40;
+    const MIN_H = 200;
+    const MIN_W = 200;
+
+    const h = Math.max(MIN_H, Math.min(height, workAreaSize.height - MARGIN));
+    const w = Math.max(MIN_W, Math.min(width, workAreaSize.width - MARGIN));
+    window.setContentSize(w, h);
+  }
+}

--- a/src/domain/appWindows/BaseDialogWindow.ts
+++ b/src/domain/appWindows/BaseDialogWindow.ts
@@ -12,6 +12,10 @@ export abstract class BaseDialogWindow {
     this.isQuitting = flag;
   }
 
+  public constructor() {
+    this.registerIpc();
+  }
+
   public async show(): Promise<void> {
     if (!this.window || this.window.isDestroyed()) {
       await this.createWindow();

--- a/src/domain/appWindows/BaseDialogWindow.ts
+++ b/src/domain/appWindows/BaseDialogWindow.ts
@@ -37,6 +37,11 @@ export abstract class BaseDialogWindow {
     this.window!.focus();
   }
 
+  public refresh(): void {
+    if (!this.window || this.window.isDestroyed()) return;
+    this.sendShowSignal();
+  }
+
   protected sendShowSignal(): void {
     const wc = this.window!.webContents;
 

--- a/src/domain/appWindows/MoveViewWindow.ts
+++ b/src/domain/appWindows/MoveViewWindow.ts
@@ -1,0 +1,34 @@
+import { BaseDialogWindow } from './BaseDialogWindow.js';
+import { ipcMain } from 'electron';
+import { App } from '../App.js';
+
+export class MoveViewWindow extends BaseDialogWindow {
+  protected preloader = 'moveViewPreload.cjs';
+  protected htmlContent = 'moveView.html';
+  protected override nodeIntegration = true;
+
+  public constructor(private readonly app: App) {
+    super();
+  }
+
+  protected registerIpc(): void {
+    if (ipcMain.listenerCount('app:move-view') > 0) return;
+
+    ipcMain.on('app:move-view', (_ev, toPaneId: string) => {
+      void (async () => {
+        const fromPane = this.app.panes.getCurrent();
+        if (!fromPane) return;
+
+        const viewId = fromPane.getCurrentViewId();
+        if (!viewId) return;
+
+        const toPane =
+          this.app.panes.get(toPaneId) ?? this.app.panes.createWindow(toPaneId);
+
+        const viewSnapshot = fromPane.snapshotViewState(viewId);
+        fromPane.closeView(viewId);
+        await toPane.restoreViewState(viewSnapshot);
+      })();
+    });
+  }
+}

--- a/src/domain/appWindows/MoveViewWindow.ts
+++ b/src/domain/appWindows/MoveViewWindow.ts
@@ -1,13 +1,13 @@
 import { BaseDialogWindow } from './BaseDialogWindow.js';
 import { ipcMain } from 'electron';
-import { App } from '../App.js';
+import { PanePool } from '../PanePool.js';
 
 export class MoveViewWindow extends BaseDialogWindow {
   protected preloader = 'moveViewPreload.cjs';
   protected htmlContent = 'moveView.html';
   protected override nodeIntegration = true;
 
-  public constructor(private readonly app: App) {
+  public constructor(private readonly panes: PanePool) {
     super();
   }
 
@@ -16,14 +16,14 @@ export class MoveViewWindow extends BaseDialogWindow {
 
     ipcMain.on('app:move-view', (_ev, toPaneId: string) => {
       void (async () => {
-        const fromPane = this.app.panes.getCurrent();
+        const fromPane = this.panes.getCurrent();
         if (!fromPane) return;
 
         const viewId = fromPane.getCurrentViewId();
         if (!viewId) return;
 
         const toPane =
-          this.app.panes.get(toPaneId) ?? this.app.panes.createWindow(toPaneId);
+          this.panes.get(toPaneId) ?? this.panes.createWindow(toPaneId);
 
         const viewSnapshot = fromPane.snapshotViewState(viewId);
         fromPane.closeView(viewId);

--- a/src/domain/appWindows/NewPaneWindow.ts
+++ b/src/domain/appWindows/NewPaneWindow.ts
@@ -1,13 +1,13 @@
 import { BaseDialogWindow } from './BaseDialogWindow.js';
 import { ipcMain } from 'electron';
-import { App } from '../App.js';
+import { PanePool } from '../PanePool.js';
 
 export class NewPaneWindow extends BaseDialogWindow {
   protected preloader = 'newPanePreload.cjs';
   protected htmlContent = 'newPane.html';
   protected override nodeIntegration = true;
 
-  public constructor(private readonly app: App) {
+  public constructor(private readonly panes: PanePool) {
     super();
   }
 
@@ -16,7 +16,7 @@ export class NewPaneWindow extends BaseDialogWindow {
 
     ipcMain.on('app:new-pane', (_ev, payload: { id: string }) => {
       try {
-        const pane = this.app.panes.createWindow(payload.id);
+        const pane = this.panes.createWindow(payload.id);
         pane.window.focus();
       } catch (err) {
         console.error('Failed to open view', err);

--- a/src/domain/appWindows/NewPaneWindow.ts
+++ b/src/domain/appWindows/NewPaneWindow.ts
@@ -1,0 +1,26 @@
+import { BaseDialogWindow } from './BaseDialogWindow.js';
+import { ipcMain } from 'electron';
+import { App } from '../App.js';
+
+export class NewPaneWindow extends BaseDialogWindow {
+  protected preloader = 'newPanePreload.cjs';
+  protected htmlContent = 'newPane.html';
+  protected override nodeIntegration = true;
+
+  public constructor(private readonly app: App) {
+    super();
+  }
+
+  protected registerIpc(): void {
+    if (ipcMain.listenerCount('app:new-pane') > 0) return;
+
+    ipcMain.on('app:new-pane', (_ev, payload: { id: string }) => {
+      try {
+        const pane = this.app.panes.createWindow(payload.id);
+        pane.window.focus();
+      } catch (err) {
+        console.error('Failed to open view', err);
+      }
+    });
+  }
+}

--- a/src/domain/appWindows/OpenViewWindow.ts
+++ b/src/domain/appWindows/OpenViewWindow.ts
@@ -1,13 +1,13 @@
 import { ipcMain, shell } from 'electron';
-import { App } from '../App.js';
 import { BaseDialogWindow } from './BaseDialogWindow.js';
+import { PanePool } from '../PanePool.js';
 
 export class OpenViewWindow extends BaseDialogWindow {
   protected preloader = 'openViewPreload.cjs';
   protected htmlContent = 'openView.html';
   protected override nodeIntegration = true;
 
-  public constructor(private readonly app: App) {
+  public constructor(private readonly panes: PanePool) {
     super();
   }
 
@@ -30,8 +30,8 @@ export class OpenViewWindow extends BaseDialogWindow {
         const { id, url, paneName } = payload;
         try {
           const pane =
-            this.app.panes.get(paneName) ??
-            this.app.panes.createWindow(paneName);
+            this.panes.get(paneName) ??
+            this.panes.createWindow(paneName);
 
           void pane.createView(id, url).then(() => pane.displayView(id));
         } catch (err) {

--- a/src/domain/appWindows/OpenViewWindow.ts
+++ b/src/domain/appWindows/OpenViewWindow.ts
@@ -1,0 +1,51 @@
+import { ipcMain, shell } from 'electron';
+import { App } from '../App.js';
+import { BaseDialogWindow } from './BaseDialogWindow.js';
+
+export class OpenViewWindow extends BaseDialogWindow {
+  protected preloader = 'openViewPreload.cjs';
+  protected htmlContent = 'openView.html';
+  protected override nodeIntegration = true;
+
+  public constructor(private readonly app: App) {
+    super();
+    this.registerIpc();
+  }
+
+  public override async createWindow(): Promise<void> {
+    await super.createWindow();
+
+    this.window!.webContents.setWindowOpenHandler(({ url }) => {
+      void shell.openExternal(url);
+
+      return { action: 'deny' };
+    });
+  }
+
+  protected registerIpc() {
+    if (ipcMain.listenerCount('app:list-panes') > 0) return;
+
+    ipcMain.handle('app:list-panes', () => {
+      const panes = this.app.panes.pool.keys().toArray();
+      const current = this.app.panes.getActive()?.name ?? 'main';
+
+      return { current, panes };
+    });
+
+    ipcMain.on(
+      'app:open-url',
+      (_ev, payload: { url: string; id: string; paneName: string }) => {
+        const { id, url, paneName } = payload;
+        try {
+          const pane =
+            this.app.panes.get(paneName) ??
+            this.app.panes.createWindow(paneName);
+
+          void pane.createView(id, url).then(() => pane.displayView(id));
+        } catch (err) {
+          console.error('Failed to open view', err);
+        }
+      },
+    );
+  }
+}

--- a/src/domain/appWindows/OpenViewWindow.ts
+++ b/src/domain/appWindows/OpenViewWindow.ts
@@ -9,7 +9,6 @@ export class OpenViewWindow extends BaseDialogWindow {
 
   public constructor(private readonly app: App) {
     super();
-    this.registerIpc();
   }
 
   public override async createWindow(): Promise<void> {
@@ -23,14 +22,7 @@ export class OpenViewWindow extends BaseDialogWindow {
   }
 
   protected registerIpc() {
-    if (ipcMain.listenerCount('app:list-panes') > 0) return;
-
-    ipcMain.handle('app:list-panes', () => {
-      const panes = this.app.panes.pool.keys().toArray();
-      const current = this.app.panes.getActive()?.name ?? 'main';
-
-      return { current, panes };
-    });
+    if (ipcMain.listenerCount('app:open-url') > 0) return;
 
     ipcMain.on(
       'app:open-url',

--- a/src/domain/appWindows/PreferencesWindow.ts
+++ b/src/domain/appWindows/PreferencesWindow.ts
@@ -1,125 +1,30 @@
-import { BrowserWindow, ipcMain, screen } from 'electron';
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { ipcMain } from 'electron';
 import { container } from 'tsyringe';
 import { ConfigService } from '../ConfigService.js';
-import { TranslationService } from '../TranslationService.js';
 import type { AppUiConfig } from '../../types/AppConfig.js';
-import type { PreferencesWindowTranslations } from '../../types/TranslationStrings.js';
+import { BaseDialogWindow } from './BaseDialogWindow.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+export class PreferencesWindow extends BaseDialogWindow {
+  protected preloader = 'preferencesWindowPreload.cjs';
+  protected htmlContent = 'preferences.html';
 
-export class PreferencesWindow {
   private readonly configService = container.resolve(ConfigService);
-  private readonly translationService = container.resolve(TranslationService);
-  public window?: BrowserWindow | undefined;
   private doRecreate = {
     showWindowFrame: true,
     showAppMenu: false,
     showInWindowList: process.platform === 'linux',
   };
-  private isQuitting = false;
 
   public constructor(
     private readonly applyUiFn: (ui: AppUiConfig) => void,
     private readonly recreateFn: () => Promise<void>,
   ) {
+    super();
     this.registerIpc();
   }
 
-  public setQuitting(flag: boolean) {
-    this.isQuitting = flag;
-  }
-
-  public async show(): Promise<void> {
-    if (!this.window?.isDestroyed()) {
-      await this.createWindow();
-    }
-
-    this.window!.show();
-    this.window!.focus();
-  }
-
-  private async createWindow(): Promise<void> {
-    const window = new BrowserWindow({
-      width: 420,
-      height: 280,
-      resizable: false,
-      roundedCorners: true,
-      useContentSize: true,
-      minimizable: false,
-      maximizable: false,
-      alwaysOnTop: true,
-      autoHideMenuBar: true,
-      modal: true,
-      show: false,
-      frame: false,
-      type: 'utility',
-      titleBarStyle: 'hidden',
-      webPreferences: {
-        contextIsolation: true,
-        enablePreferredSizeMode: true,
-        nodeIntegration: false,
-        preload: join(__dirname, '../../preload/preferencesWindowPreload.cjs'),
-        sandbox: false,
-        webviewTag: false,
-        zoomFactor: 1,
-      },
-    });
-
-    window.webContents.on(
-      'preferred-size-changed',
-      (_ev, preferred: Electron.Size) => {
-        void this.fitToHeight(window, preferred.height);
-      },
-    );
-
-    window.webContents.once('did-finish-load', () => {
-      try {
-        void this.fitToHeight(window);
-      } finally {
-        window.show();
-      }
-    });
-
-    window.on('close', (e) => {
-      if (this.isQuitting) return;
-
-      e.preventDefault();
-      this.window?.hide();
-    });
-
-    window.on('closed', () => {
-      this.window = undefined;
-    });
-
-    await window.loadFile(
-      join(import.meta.dirname, '../../renderer/preferences.html'),
-    );
-
-    this.window = window;
-  }
-
-  private async fitToHeight(window: BrowserWindow, desiredHeight?: number) {
-    const height =
-      desiredHeight ??
-      ((await window.webContents.executeJavaScript(
-        'Math.ceil(document.documentElement.scrollHeight)',
-      )) as number);
-    if (window.isDestroyed()) return;
-
-    const { workAreaSize } = screen.getDisplayMatching(window.getBounds());
-    const MARGIN = 40;
-    const MIN_H = 200;
-
-    const [contentW] = window.getContentSize();
-    const h = Math.max(MIN_H, Math.min(height, workAreaSize.height - MARGIN));
-    window.setContentSize(contentW ?? 400, h);
-  }
-
-  private registerIpc(): void {
-    if (ipcMain.listenerCount('preferences:get') > 0) return;
+  protected registerIpc(): void {
+    if (ipcMain.listenerCount('prefs:get-ui') > 0) return;
 
     ipcMain.handle('prefs:get-ui', () => this.configService.get('ui'));
 
@@ -135,12 +40,6 @@ export class PreferencesWindow {
       }
 
       this.applyUiFn(after);
-    });
-
-    ipcMain.handle('i18n:t', (_e, key: keyof PreferencesWindowTranslations) => {
-      const lang = this.configService.get('lang');
-
-      return this.translationService.get(lang, `windows.preferences.${key}`);
     });
   }
 }

--- a/src/domain/appWindows/PreferencesWindow.ts
+++ b/src/domain/appWindows/PreferencesWindow.ts
@@ -31,7 +31,7 @@ export class PreferencesWindow extends BaseDialogWindow {
     ipcMain.handle('prefs:get-ui', () => this.configService.get('ui'));
 
     ipcMain.on('prefs:set-ui', (_e, patch: Partial<AppUiConfig>) => {
-      const before = this.configService.get('ui');
+      const before = { ...this.configService.get('ui') };
       this.configService.save({ ui: patch });
       const after = this.configService.get('ui');
 

--- a/src/domain/appWindows/PreferencesWindow.ts
+++ b/src/domain/appWindows/PreferencesWindow.ts
@@ -20,7 +20,6 @@ export class PreferencesWindow extends BaseDialogWindow {
     private readonly recreateFn: () => Promise<void>,
   ) {
     super();
-    this.registerIpc();
   }
 
   protected registerIpc(): void {

--- a/src/exceptions/InvalidUrlException.ts
+++ b/src/exceptions/InvalidUrlException.ts
@@ -8,7 +8,7 @@ export class InvalidUrlException extends Error {
     const configService = container.resolve(ConfigService);
     const translationService = container.resolve(TranslationService);
     const translations = translationService.get(
-      configService.get('lang'),
+      configService.get('ui.lang'),
       'error.url',
     );
 

--- a/src/parseCli.ts
+++ b/src/parseCli.ts
@@ -5,6 +5,7 @@ import { ConfigService } from './domain/ConfigService.js';
 import { TranslationService } from './domain/TranslationService.js';
 import { InvalidUrlException } from './exceptions/InvalidUrlException.js';
 import colors from 'yoctocolors';
+import { makeId } from './utils/makeId.js';
 
 export type CliOutputArgs =
   | {
@@ -71,10 +72,4 @@ export function parseCli(argv: string[]) {
     .version()
     .help()
     .parseSync() as CliOutputArgs;
-}
-
-function makeId(url: string) {
-  const u = new URL(url);
-
-  return u.hostname;
 }

--- a/src/parseCli.ts
+++ b/src/parseCli.ts
@@ -9,15 +9,15 @@ import { makeId } from './utils/makeId.js';
 
 export type CliOutputArgs =
   | {
-      url: string;
-      id: string;
-      target: string;
-    }
+    url: string;
+    id: string;
+    target: string;
+  }
   | {
-      url: undefined;
-      id: undefined;
-      target: string;
-    };
+    url: undefined;
+    id: undefined;
+    target: string;
+  };
 
 export function parseCli(argv: string[]) {
   return yargs(argv)
@@ -62,7 +62,7 @@ export function parseCli(argv: string[]) {
     .exitProcess(false)
     .fail((msg, err, yargs) => {
       yargs.showHelp();
-      const lang = container.resolve(ConfigService).get('lang');
+      const lang = container.resolve(ConfigService).get('ui.lang');
       const t = container.resolve(TranslationService);
       const out = msg || err.message || t.get(lang, 'error.unknown');
       console.error('\n' + colors.red(t.get(lang, 'error.error')) + '\n' + out);

--- a/src/preload/aboutPreload.ts
+++ b/src/preload/aboutPreload.ts
@@ -1,0 +1,8 @@
+import { contextBridge, ipcRenderer } from 'electron';
+import './commonDialogPreload.cjs';
+
+contextBridge.exposeInMainWorld('about', {
+  getInfo: async () => {
+    return await ipcRenderer.invoke('about:get-info');
+  },
+});

--- a/src/preload/aboutPreload.ts
+++ b/src/preload/aboutPreload.ts
@@ -5,4 +5,7 @@ contextBridge.exposeInMainWorld('about', {
   getInfo: async () => {
     return await ipcRenderer.invoke('about:get-info');
   },
+  openExternal: (url: string) => {
+    ipcRenderer.send('about:open-external', url);
+  },
 });

--- a/src/preload/commonDialogPreload.ts
+++ b/src/preload/commonDialogPreload.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
+import type { IpcRendererEvent } from 'electron';
 import type { Lang } from '../types/Lang.js';
 import type { TranslationStrings } from '../types/TranslationStrings.js';
 import type { DotPath, PathValue } from '../types/ConfigTypes.js';
@@ -12,6 +13,12 @@ contextBridge.exposeInMainWorld('dialog', {
 });
 
 contextBridge.exposeInMainWorld('i18n', {
+  onLanguageChanged: (cb: (lang: Lang) => void) => {
+    const handler = (_: IpcRendererEvent, lang: Lang) => cb(lang);
+    ipcRenderer.on('i18n:language-changed', handler);
+    return () => ipcRenderer.removeListener('i18n:language-changed', handler);
+  },
+
   t<P extends DotPath<TranslationStrings>>(
     key: P,
     lang?: Lang,

--- a/src/preload/commonDialogPreload.ts
+++ b/src/preload/commonDialogPreload.ts
@@ -1,0 +1,25 @@
+import { contextBridge, ipcRenderer } from 'electron';
+import type { Lang } from '../types/Lang.js';
+import type { TranslationStrings } from '../types/TranslationStrings.js';
+import type { DotPath, PathValue } from '../types/ConfigTypes.js';
+
+contextBridge.exposeInMainWorld('dialog', {
+  onShow: (cb: () => void) => {
+    const handler = () => cb();
+    ipcRenderer.on('dialog:show', handler);
+    return () => ipcRenderer.removeListener('dialog:show', handler);
+  },
+});
+
+contextBridge.exposeInMainWorld('i18n', {
+  t<P extends DotPath<TranslationStrings>>(
+    key: P,
+    lang?: Lang,
+  ): Promise<PathValue<TranslationStrings, P>> {
+    return ipcRenderer.invoke('i18n:t', key, lang);
+  },
+
+  bundle(lang?: Lang): Promise<TranslationStrings> {
+    return ipcRenderer.invoke('i18n:bundle', lang);
+  },
+});

--- a/src/preload/moveViewPreload.ts
+++ b/src/preload/moveViewPreload.ts
@@ -1,0 +1,56 @@
+import { contextBridge, ipcRenderer } from 'electron';
+import { z } from 'zod';
+import './commonDialogPreload.cjs';
+import { PanesInfo } from '../types/PanesInfo.js';
+import { MoveViewPayload } from '../types/MoveView.js';
+import { ValidationResult } from '../types/validation.js';
+
+contextBridge.exposeInMainWorld('moveView', {
+  getPanes: async (): Promise<{ current: string; panes: string[] }> => {
+    return ipcRenderer.invoke('app:list-panes');
+  },
+  doMoveView: (toPaneId: string) => {
+    ipcRenderer.send('app:move-view', toPaneId);
+  },
+  validate: (
+    candidate: Candidate,
+    panesInfo: PanesInfo,
+  ): ValidationResult<MoveViewPayload> => {
+    return validate(candidate, panesInfo);
+  },
+});
+
+const CandidateSchema = z.object({
+  toPaneId: z.string().trim().min(1),
+});
+type Candidate = z.infer<typeof CandidateSchema>;
+
+function validate(
+  input: Candidate,
+  panesInfo: PanesInfo,
+): ValidationResult<MoveViewPayload> {
+  const base = CandidateSchema.safeParse(input);
+  if (!base.success) {
+    const errs = base.error.issues.map((iss) => {
+      return {
+        fieldId: 'paneNewName',
+        message: iss.message,
+      };
+    });
+    return { ok: false, fieldErrors: errs };
+  }
+
+  const { toPaneId } = base.data;
+  const { current } = panesInfo;
+
+  if (toPaneId === current) {
+    return {
+      ok: false,
+      fieldErrors: [
+        { fieldId: 'paneNewName', message: 'current_pane_invalid' },
+      ],
+    };
+  }
+
+  return { ok: true, data: { toPaneId } };
+}

--- a/src/preload/newPanePreload.ts
+++ b/src/preload/newPanePreload.ts
@@ -1,0 +1,50 @@
+import { contextBridge, ipcRenderer } from 'electron';
+import { z } from 'zod';
+import './commonDialogPreload.cjs';
+import { PanesInfo } from '../types/PanesInfo.js';
+import { ValidationResult } from '../types/validation.js';
+
+type Candidate = { id: string | undefined };
+type Payload = { id: string };
+
+contextBridge.exposeInMainWorld('newPane', {
+  createPane: (id: string) => {
+    ipcRenderer.send('app:new-pane', { id });
+  },
+  getPanes: async (): Promise<string[]> => {
+    const panesInfo = (await ipcRenderer.invoke('app:list-panes')) as PanesInfo;
+
+    return panesInfo.panes;
+  },
+  validate: (
+    candidate: Candidate,
+    panes: string[],
+  ): ValidationResult<Payload> => {
+    return validate(candidate, panes);
+  },
+});
+
+const CandidateSchema = z.object({
+  id: z.string().trim().min(1),
+});
+
+function validate(
+  input: Candidate,
+  panes: string[],
+): ValidationResult<Payload> {
+  const base = CandidateSchema.refine((vals) => !panes.includes(vals.id), {
+    message: 'already_exists',
+  }).safeParse(input);
+
+  if (!base.success) {
+    const errs = base.error.issues.map((iss) => {
+      return {
+        fieldId: 'newPaneId',
+        message: iss.message,
+      };
+    });
+    return { ok: false, fieldErrors: errs };
+  }
+
+  return { ok: true, data: { id: base.data.id } };
+}

--- a/src/preload/openViewPreload.ts
+++ b/src/preload/openViewPreload.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { makeId } from '../utils/makeId.js';
 import './commonDialogPreload.cjs';
 import { OpenViewPaneChoice, OpenViewPayload } from '../types/OpenView.js';
+import { PanesInfo } from '../types/PanesInfo.js';
 
 contextBridge.exposeInMainWorld('openView', {
   getPanes: async (): Promise<{ current: string; panes: string[] }> => {
@@ -15,8 +16,6 @@ contextBridge.exposeInMainWorld('openView', {
     return validateWithPanes(candidate, panesInfo);
   },
 });
-
-type PanesInfo = { current: string; panes: string[] };
 
 type Candidate = {
   url: string;

--- a/src/preload/openViewPreload.ts
+++ b/src/preload/openViewPreload.ts
@@ -1,0 +1,126 @@
+import { contextBridge, ipcRenderer } from 'electron';
+import { z } from 'zod';
+import { makeId } from '../utils/makeId.js';
+import './commonDialogPreload.cjs';
+import { OpenViewPaneChoice, OpenViewPayload } from '../types/OpenView.js';
+
+contextBridge.exposeInMainWorld('openView', {
+  getPanes: async (): Promise<{ current: string; panes: string[] }> => {
+    return ipcRenderer.invoke('app:list-panes');
+  },
+  openUrl: (payload: OpenViewPayload) => {
+    ipcRenderer.send('app:open-url', payload);
+  },
+  validate: (candidate: Candidate, panesInfo: PanesInfo): ValidateResult => {
+    return validateWithPanes(candidate, panesInfo);
+  },
+});
+
+type PanesInfo = { current: string; panes: string[] };
+
+type Candidate = {
+  url: string;
+  id: string | undefined;
+  pane: {
+    paneChoice: string;
+    paneExistingName: string | undefined;
+    paneNewName: string | undefined;
+  };
+};
+
+type Payload = { url: string; id: string; paneName: string };
+
+type ValidateOk = { ok: true; data: Payload };
+type ValidateErr = {
+  ok: false;
+  fieldErrors: { fieldId: string; messageKey: string }[];
+};
+type ValidateResult = ValidateOk | ValidateErr;
+
+const UrlField = z
+  .string()
+  .trim()
+  .min(7, { message: 'required' })
+  .refine(
+    (v) => {
+      try {
+        new URL(v);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { message: 'invalid_url' },
+  );
+
+const PaneChoiceSchema = z.object({
+  paneChoice: z.enum(OpenViewPaneChoice),
+  paneExistingName: z.string().trim().optional(),
+  paneNewName: z.string().trim().optional(),
+});
+
+const CandidateSchema = z
+  .object({
+    url: UrlField,
+    id: z.string().trim().optional(),
+    pane: PaneChoiceSchema,
+  })
+  .transform(({ url, id, pane }) => {
+    const normalizedUrl = new URL(url).toString();
+    const finalId = id && id.length > 0 ? id : makeId(normalizedUrl);
+    return { url: normalizedUrl, id: finalId, pane };
+  });
+
+function validateWithPanes(
+  input: Candidate,
+  panesInfo: PanesInfo,
+): ValidateResult {
+  const base = CandidateSchema.safeParse(input);
+  if (!base.success) {
+    const errs = base.error.issues.map((iss) => {
+      const field = String(iss.path[0] ?? 'url');
+      return {
+        fieldId: field === 'id' ? 'openViewId' : 'openViewUrl',
+        messageKey: iss.message,
+      };
+    });
+    return { ok: false, fieldErrors: errs };
+  }
+
+  const { url, id, pane } = base.data;
+  const { current, panes } = panesInfo;
+
+  if (pane.paneChoice === OpenViewPaneChoice.CURRENT) {
+    return { ok: true, data: { url, id, paneName: current } };
+  }
+
+  if (pane.paneChoice === OpenViewPaneChoice.EXISTING) {
+    const sel = pane.paneExistingName?.trim();
+    if (!sel || !panes.includes(sel)) {
+      return {
+        ok: false,
+        fieldErrors: [
+          { fieldId: 'paneExistingSelect', messageKey: 'required' },
+        ],
+      };
+    }
+    return { ok: true, data: { url, id, paneName: sel } };
+  }
+
+  // OpenViewPaneChoice.NEW
+  const name = pane.paneNewName?.trim() ?? '';
+  if (!name) {
+    return {
+      ok: false,
+      fieldErrors: [{ fieldId: 'paneNewName', messageKey: 'required' }],
+    };
+  }
+  if (panes.includes(name)) {
+    return {
+      ok: false,
+      fieldErrors: [{ fieldId: 'paneNewName', messageKey: 'already_exists' }],
+    };
+  }
+
+  return { ok: true, data: { url, id, paneName: name } };
+}

--- a/src/preload/preferencesWindowPreload.ts
+++ b/src/preload/preferencesWindowPreload.ts
@@ -1,14 +1,12 @@
 import { contextBridge, ipcRenderer } from 'electron';
 import type { AppUiConfig } from '../types/AppConfig.js';
-import type { PreferencesWindowTranslations } from '../types/TranslationStrings.js';
+import './commonDialogPreload.cjs';
 
-contextBridge.exposeInMainWorld('prefsAPI', {
+contextBridge.exposeInMainWorld('preferences', {
   get: (): Promise<AppUiConfig> => ipcRenderer.invoke('prefs:get-ui'),
   set: (patch: Partial<AppUiConfig>): void => {
     ipcRenderer.send('prefs:set-ui', patch);
   },
-  t: (key: keyof PreferencesWindowTranslations): Promise<string> =>
-    ipcRenderer.invoke('i18n:t', key),
   info: {
     platform: process.platform,
   },

--- a/src/renderer/about.html
+++ b/src/renderer/about.html
@@ -31,7 +31,8 @@
                     <div class="col-12">
                         <div class="row g-2">
                             <div class="col-sm-3 text-body-secondary" id="appAuthorLabel"></div>
-                            <div class="col-sm-9"><a id="appAuthor" href="#" target="_blank"></a></div>
+                            <div class="col-sm-9"><a id="appAuthor" class="external-link" href="#"
+                                    target="_blank"></a></div>
                         </div>
                     </div>
                     <div class="col-12">
@@ -46,21 +47,24 @@
                     <div class="col-12">
                         <div class="row g-2">
                             <div class="col-sm-3 text-body-secondary" id="appHomepageLabel"></div>
-                            <div class="col-sm-9"><small><a id="appHomepage" href="#" target="_blank"></a></small>
+                            <div class="col-sm-9"><small><a id="appHomepage" class="external-link" href="#"
+                                        target="_blank"></a></small>
                             </div>
                         </div>
                     </div>
                     <div class="col-12">
                         <div class="row g-2">
                             <div class="col-sm-3 text-body-secondary" id="appRepositoryLabel"></div>
-                            <div class="col-sm-9"><small><a id="appRepository" href="#" target="_blank"></a></small>
+                            <div class="col-sm-9"><small><a id="appRepository" class="external-link" href="#"
+                                        target="_blank"></a></small>
                             </div>
                         </div>
                     </div>
                     <div class="col-12">
                         <div class="row g-2">
                             <div class="col-sm-3 text-body-secondary" id="appBugsLabel"></div>
-                            <div class="col-sm-9"><small><a id="appBugs" href="#" target="_blank"></a></small>
+                            <div class="col-sm-9"><small><a id="appBugs" class="external-link" href="#"
+                                        target="_blank"></a></small>
                             </div>
                         </div>
                     </div>

--- a/src/renderer/about.html
+++ b/src/renderer/about.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="pl" data-bs-theme="light">
+
+<head>
+    <title id="docTitle"></title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+
+    <link rel="stylesheet" href="../../assets/bootstrap.min.css" />
+    <link rel="stylesheet" href="../../assets/appWindows.css" />
+    <script type="module" src="../../assets/motif.js"></script>
+</head>
+
+<body>
+    <div class="window">
+        <!-- TITLE BAR -->
+        <header class="window__header">
+            <h1 class="window__title" id="aboutTitle"></h1>
+            <button type="button" class="btn btn-close window__close" id="btnClose" aria-label="Zamknij"></button>
+        </header>
+
+        <!-- MAIN CONTENT -->
+        <main class="window__main" style="width:600px">
+            <div class=" container py-3">
+                <div class="row g-3 align-items-start">
+                    <div class="col">
+                        <span class="fs-3 fw-bold" id="appName"></span>
+                        <span class="fs-5 text-body-secondary" id="appVersion"></span>
+                    </div>
+                    <div class="col-12">
+                        <div class="row g-2">
+                            <div class="col-sm-3 text-body-secondary" id="appAuthorLabel"></div>
+                            <div class="col-sm-9"><a id="appAuthor" href="#" target="_blank"></a></div>
+                        </div>
+                    </div>
+                    <div class="col-12">
+                        <div class="row g-2">
+                            <div class="col-sm-3 text-body-secondary" id="appLicenseLabel"></div>
+                            <div class="col-sm-9" id="appLicense"></div>
+                        </div>
+                    </div>
+                    <div class="col pt-2">
+                        <p id="pagesLabel"></p>
+                    </div>
+                    <div class="col-12">
+                        <div class="row g-2">
+                            <div class="col-sm-3 text-body-secondary" id="appHomepageLabel"></div>
+                            <div class="col-sm-9"><small><a id="appHomepage" href="#" target="_blank"></a></small>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-12">
+                        <div class="row g-2">
+                            <div class="col-sm-3 text-body-secondary" id="appRepositoryLabel"></div>
+                            <div class="col-sm-9"><small><a id="appRepository" href="#" target="_blank"></a></small>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-12">
+                        <div class="row g-2">
+                            <div class="col-sm-3 text-body-secondary" id="appBugsLabel"></div>
+                            <div class="col-sm-9"><small><a id="appBugs" href="#" target="_blank"></a></small>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </main>
+
+        <!-- BUTTON BAR -->
+        <footer class="window__footer">
+            <button id="btnCloseB" type="button" class="btn btn-primary">
+                ✕ <span id="btnCloseBLabel"></span>
+            </button>
+        </footer>
+    </div>
+
+    <script type="module" src="./about.js"></script>
+</body>
+
+</html>

--- a/src/renderer/about.ts
+++ b/src/renderer/about.ts
@@ -1,0 +1,53 @@
+import type { AboutWindowTranslations } from '../types/TranslationStrings.js';
+import { DotPath } from '../types/ConfigTypes.js';
+import { getTyped } from '../utils/object.js';
+import { el } from '../utils/dom.js';
+
+const translations: Record<string, DotPath<AboutWindowTranslations>> = {
+  docTitle: 'title',
+  aboutTitle: 'title',
+  appAuthorLabel: 'author',
+  appLicenseLabel: 'license',
+  appHomepageLabel: 'homepage',
+  appRepositoryLabel: 'repository',
+  appBugsLabel: 'bugs',
+  btnCloseBLabel: 'close',
+};
+
+async function main() {
+  const t = await window.i18n.bundle();
+
+  for (const [id, translationKey] of Object.entries(translations)) {
+    const value = getTyped(
+      t,
+      `windows.about.${translationKey}`,
+    ) as unknown;
+    el(id).textContent = typeof value === 'string' ? value : '';
+  }
+
+  const appInfo = await window.about.getInfo();
+
+  el('appName').textContent = appInfo.name;
+  el('appVersion').textContent = appInfo.version;
+  el('appAuthor').textContent = appInfo.author.name;
+  el<HTMLAnchorElement>('appAuthor').href = appInfo.author.url;
+  el('appLicense').textContent = appInfo.license;
+  el('appHomepage').textContent = appInfo.homepage;
+  el<HTMLAnchorElement>('appHomepage').href = appInfo.homepage;
+  el('appRepository').textContent = appInfo.repository;
+  el<HTMLAnchorElement>('appRepository').href = appInfo.repository;
+  el('appBugs').textContent = appInfo.bugs;
+  el<HTMLAnchorElement>('appBugs').href = appInfo.bugs;
+
+  const close = () => {
+    window.close();
+  };
+  el('btnClose').addEventListener('click', close);
+  el('btnCloseB').addEventListener('click', close);
+  window.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') window.close();
+  });
+}
+
+void main().catch(console.error);
+export { };

--- a/src/renderer/about.ts
+++ b/src/renderer/about.ts
@@ -47,7 +47,7 @@ document.addEventListener('DOMContentLoaded', () => {
     await applyTranslations();
     await renderAppInfo();
 
-    window.dialog.onShow(() => {
+    window.i18n.onLanguageChanged(() => {
       void applyTranslations();
     });
 
@@ -72,4 +72,4 @@ document.addEventListener('DOMContentLoaded', () => {
   })();
 });
 
-export {};
+export { };

--- a/src/renderer/moveView.html
+++ b/src/renderer/moveView.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="pl" data-bs-theme="light">
+<head>
+    <title id="docTitle"></title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+
+    <link rel="stylesheet" href="../../assets/bootstrap.min.css" />
+    <link rel="stylesheet" href="../../assets/appWindows.css" />
+    <script type="module" src="../../assets/motif.js"></script>
+</head>
+<body>
+<div class="window">
+    <!-- TITLE BAR -->
+    <header class="window__header">
+        <h1 class="window__title" id="moveViewTitle" data-i18n="doMoveView.title"></h1>
+        <button type="button" class="btn btn-close window__close" id="btnClose"
+                aria-label="Zamknij" data-i18n-aria-label="common.close"></button>
+    </header>
+
+    <!-- MAIN CONTENT -->
+    <main class="window__main">
+        <form id="moveViewForm" class="form-grid" novalidate>
+                <div class="pane-choice">
+                    <label class="form-label" id="paneChoice_label"></label>
+                    <div>
+                        <div class="form-check" id="paneExistingWrap">
+                            <input class="form-check-input" type="radio" name="paneChoice" id="paneChoice_existing" value="existing" disabled />
+                            <label class="form-check-label me-2" id="paneChoice_existing_label" for="paneChoice_existing"></label>
+                            <select class="form-select d-inline-block w-auto align-middle" id="paneExistingSelect" disabled aria-label="Pane select"></select>
+                            <div class="invalid-feedback" id="paneExistingError"></div>
+                        </div>
+
+                        <div class="form-check">
+                            <input checked class="form-check-input" type="radio" name="paneChoice" id="paneChoice_new" value="new" />
+                            <label class="form-check-label me-2" id="paneChoice_new_label" for="paneChoice_new"></label>
+                            <input type="text" class="form-control d-inline-block w-auto align-middle"
+                                   id="paneNewName" disabled />
+                            <div class="invalid-feedback" id="paneNewNameError"></div>
+                        </div>
+                    </div>
+                </div>
+        </form>
+    </main>
+
+    <!-- BUTTON BAR -->
+    <footer class="window__footer">
+        <button type="button" class="btn btn-secondary" id="btnCancel"></button>
+        <button type="submit" form="moveViewForm" class="btn btn-primary" id="btnSubmit" disabled></button>
+    </footer>
+</div>
+
+<script src="../../assets/bootstrap.bundle.min.js"></script>
+<script type="module" src="./moveView.js"></script>
+</body>
+</html>

--- a/src/renderer/moveView.ts
+++ b/src/renderer/moveView.ts
@@ -23,7 +23,7 @@ function applyFieldErrors(list: ValidationError[]) {
   }
 }
 
-async function setupTranslations() {
+async function applyTranslations() {
   const t = await window.i18n.bundle();
 
   const translations: Record<string, DotPath<MoveViewWindowTranslations>> = {
@@ -153,14 +153,17 @@ async function refreshPanes() {
 
 document.addEventListener('DOMContentLoaded', () => {
   void (async () => {
-    await setupTranslations();
-
+    await applyTranslations();
     void refreshPanes();
     wireLiveValidation();
+
     window.dialog.onShow(() => {
-      void setupTranslations();
       resetFormUi();
       void refreshPanes();
+    });
+
+    window.i18n.onLanguageChanged(() => {
+      void applyTranslations();
     });
 
     setTimeout(() => {

--- a/src/renderer/moveView.ts
+++ b/src/renderer/moveView.ts
@@ -48,7 +48,6 @@ async function setupTranslations() {
 }
 
 function setupPaneSection(info: PanesInfo) {
-  // const wrap = document.getElementById('paneExistingWrap')!;
   const rExist = document.getElementById(
     'paneChoice_existing',
   ) as HTMLInputElement;
@@ -159,6 +158,7 @@ document.addEventListener('DOMContentLoaded', () => {
     void refreshPanes();
     wireLiveValidation();
     window.dialog.onShow(() => {
+      void setupTranslations();
       resetFormUi();
       void refreshPanes();
     });

--- a/src/renderer/newPane.html
+++ b/src/renderer/newPane.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="pl" data-bs-theme="light">
+<head>
+    <title id="docTitle" data-i18n="newPane.title"></title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+
+    <link rel="stylesheet" href="../../assets/bootstrap.min.css" />
+    <link rel="stylesheet" href="../../assets/appWindows.css" />
+    <script type="module" src="../../assets/motif.js"></script>
+</head>
+<body>
+<div class="window">
+    <!-- TITLE BAR -->
+    <header class="window__header">
+        <h1 class="window__title" id="newPaneTitle" data-i18n="newPane.title"></h1>
+        <button type="button" class="btn btn-close window__close" id="btnClose"
+                aria-label="Zamknij" data-i18n-aria-label="common.close"></button>
+    </header>
+
+    <!-- MAIN CONTENT -->
+    <main class="window__main">
+        <form id="newPaneForm" class="form-grid" novalidate>
+            <div class="form-row">
+                <label id="newPaneIdLabel" for="newPaneId" class="form-label"></label>
+                <div>
+                    <input type="text" class="form-control" id="newPaneId" name="url" required />
+                    <div class="invalid-feedback" id="newPaneIdError"></div>
+                </div>
+            </div>
+        </form>
+    </main>
+
+    <!-- BUTTON BAR -->
+    <footer class="window__footer">
+        <button type="button" class="btn btn-secondary" id="btnCancel"></button>
+        <button type="submit" form="newPaneForm" class="btn btn-primary" id="btnSubmit" disabled></button>
+    </footer>
+</div>
+
+<script src="../../assets/bootstrap.bundle.min.js"></script>
+<script type="module" src="./newPane.js"></script>
+</body>
+</html>

--- a/src/renderer/newPane.html
+++ b/src/renderer/newPane.html
@@ -1,7 +1,8 @@
 <!doctype html>
 <html lang="pl" data-bs-theme="light">
+
 <head>
-    <title id="docTitle" data-i18n="newPane.title"></title>
+    <title id="docTitle"></title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
@@ -10,36 +11,37 @@
     <link rel="stylesheet" href="../../assets/appWindows.css" />
     <script type="module" src="../../assets/motif.js"></script>
 </head>
+
 <body>
-<div class="window">
-    <!-- TITLE BAR -->
-    <header class="window__header">
-        <h1 class="window__title" id="newPaneTitle" data-i18n="newPane.title"></h1>
-        <button type="button" class="btn btn-close window__close" id="btnClose"
-                aria-label="Zamknij" data-i18n-aria-label="common.close"></button>
-    </header>
+    <div class="window">
+        <!-- TITLE BAR -->
+        <header class="window__header">
+            <h1 class="window__title" id="newPaneTitle"></h1>
+            <button type="button" class="btn btn-close window__close" id="btnClose" aria-label="Zamknij"></button>
+        </header>
 
-    <!-- MAIN CONTENT -->
-    <main class="window__main">
-        <form id="newPaneForm" class="form-grid" novalidate>
-            <div class="form-row">
-                <label id="newPaneIdLabel" for="newPaneId" class="form-label"></label>
-                <div>
-                    <input type="text" class="form-control" id="newPaneId" name="url" required />
-                    <div class="invalid-feedback" id="newPaneIdError"></div>
+        <!-- MAIN CONTENT -->
+        <main class="window__main">
+            <form id="newPaneForm" class="form-grid" novalidate>
+                <div class="form-row">
+                    <label id="newPaneIdLabel" for="newPaneId" class="form-label"></label>
+                    <div>
+                        <input type="text" class="form-control" id="newPaneId" name="url" required />
+                        <div class="invalid-feedback" id="newPaneIdError"></div>
+                    </div>
                 </div>
-            </div>
-        </form>
-    </main>
+            </form>
+        </main>
 
-    <!-- BUTTON BAR -->
-    <footer class="window__footer">
-        <button type="button" class="btn btn-secondary" id="btnCancel"></button>
-        <button type="submit" form="newPaneForm" class="btn btn-primary" id="btnSubmit" disabled></button>
-    </footer>
-</div>
+        <!-- BUTTON BAR -->
+        <footer class="window__footer">
+            <button type="button" class="btn btn-secondary" id="btnCancel"></button>
+            <button type="submit" form="newPaneForm" class="btn btn-primary" id="btnSubmit" disabled></button>
+        </footer>
+    </div>
 
-<script src="../../assets/bootstrap.bundle.min.js"></script>
-<script type="module" src="./newPane.js"></script>
+    <script src="../../assets/bootstrap.bundle.min.js"></script>
+    <script type="module" src="./newPane.js"></script>
 </body>
+
 </html>

--- a/src/renderer/newPane.ts
+++ b/src/renderer/newPane.ts
@@ -1,0 +1,132 @@
+import type { NewPaneWindowTranslations } from '../types/TranslationStrings.js';
+import { DotPath } from '../types/ConfigTypes.js';
+import { getTyped } from '../utils/object.js';
+import { el } from '../utils/dom.js';
+
+let panesCache: string[] | undefined = undefined;
+
+function clearErrors() {
+  el('newPaneId').classList.remove('is-invalid');
+}
+
+function applyFieldErrors(list: { fieldId: string }[]) {
+  for (const e of list) {
+    el(e.fieldId).classList.add('is-invalid');
+  }
+}
+
+async function setupTranslations() {
+  const t = await window.i18n.bundle();
+
+  const translations: Record<string, DotPath<NewPaneWindowTranslations>> = {
+    docTitle: 'title',
+    newPaneTitle: 'title',
+    newPaneIdLabel: 'id.label',
+    newPaneIdError: 'id.error',
+    btnCancel: 'command.cancel',
+    btnSubmit: 'command.open',
+  };
+  for (const [id, translationKey] of Object.entries(translations)) {
+    const value = getTyped(t, `windows.newPane.${translationKey}`) as unknown;
+    el(id).textContent = typeof value === 'string' ? value : '';
+  }
+
+  el<HTMLInputElement>('newPaneId').placeholder = getTyped(
+    t,
+    'windows.newPane.id.placeholder',
+  );
+}
+
+function collectCandidate() {
+  const id = el<HTMLInputElement>('newPaneId').value || undefined;
+
+  return { id };
+}
+
+function validateForm(showErrors: boolean): boolean {
+  if (!panesCache) return false;
+
+  const candidate = collectCandidate();
+  const result = window.newPane.validate(candidate, panesCache);
+
+  const submitBtn = el<HTMLButtonElement>('btnSubmit');
+
+  if (result.ok) {
+    clearErrors();
+    submitBtn.disabled = false;
+    return true;
+  } else {
+    if (showErrors) {
+      clearErrors();
+      applyFieldErrors(result.fieldErrors);
+    }
+    submitBtn.disabled = true;
+    return false;
+  }
+}
+
+function wireLiveValidation() {
+  const id = el<HTMLInputElement>('newPaneId');
+
+  const softCheck = () => void validateForm(false);
+
+  id.addEventListener('input', softCheck);
+  id.addEventListener('blur', () => void validateForm(true));
+}
+
+function resetFormUi() {
+  el<HTMLFormElement>('newPaneForm').reset();
+  clearErrors();
+  el<HTMLButtonElement>('btnSubmit').disabled = true;
+}
+
+async function refreshPanes() {
+  panesCache = await window.newPane.getPanes();
+
+  validateForm(false);
+  setTimeout(() => {
+    el<HTMLInputElement>('newPaneId').focus();
+  }, 0);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  void (async () => {
+    await setupTranslations();
+
+    void refreshPanes();
+    wireLiveValidation();
+    window.dialog.onShow(() => {
+      resetFormUi();
+      void refreshPanes();
+    });
+
+    setTimeout(() => {
+      el<HTMLFormElement>('newPaneId').focus();
+    }, 0);
+
+    const close = () => {
+      window.close();
+    };
+    el('btnClose').addEventListener('click', close);
+    el('btnCancel').addEventListener('click', close);
+    window.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') window.close();
+    });
+
+    const form = el<HTMLFormElement>('newPaneForm');
+    form.addEventListener('submit', (ev) => {
+      ev.preventDefault();
+      clearErrors();
+
+      const result = window.newPane.validate(collectCandidate(), panesCache!);
+
+      if (!result.ok) {
+        applyFieldErrors(result.fieldErrors);
+        return;
+      }
+
+      window.newPane.createPane(result.data.id);
+      window.close();
+    });
+  })();
+});

--- a/src/renderer/newPane.ts
+++ b/src/renderer/newPane.ts
@@ -96,6 +96,7 @@ document.addEventListener('DOMContentLoaded', () => {
     void refreshPanes();
     wireLiveValidation();
     window.dialog.onShow(() => {
+      void setupTranslations();
       resetFormUi();
       void refreshPanes();
     });

--- a/src/renderer/newPane.ts
+++ b/src/renderer/newPane.ts
@@ -15,7 +15,7 @@ function applyFieldErrors(list: { fieldId: string }[]) {
   }
 }
 
-async function setupTranslations() {
+async function applyTranslations() {
   const t = await window.i18n.bundle();
 
   const translations: Record<string, DotPath<NewPaneWindowTranslations>> = {
@@ -91,14 +91,17 @@ async function refreshPanes() {
 
 document.addEventListener('DOMContentLoaded', () => {
   void (async () => {
-    await setupTranslations();
-
+    await applyTranslations();
     void refreshPanes();
     wireLiveValidation();
+
     window.dialog.onShow(() => {
-      void setupTranslations();
       resetFormUi();
       void refreshPanes();
+    });
+
+    window.i18n.onLanguageChanged(() => {
+      void applyTranslations();
     });
 
     setTimeout(() => {

--- a/src/renderer/openView.html
+++ b/src/renderer/openView.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="pl" data-bs-theme="light">
+<head>
+    <title id="docTitle" data-i18n="openView.title"></title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+
+    <link rel="stylesheet" href="../../assets/bootstrap.min.css" />
+    <link rel="stylesheet" href="../../assets/appWindows.css" />
+    <script type="module" src="../../assets/motif.js"></script>
+</head>
+<body>
+<div class="window">
+    <!-- TITLE BAR -->
+    <header class="window__header">
+        <h1 class="window__title" id="openViewTitle" data-i18n="openView.title"></h1>
+        <button type="button" class="btn btn-close window__close" id="btnClose"
+                aria-label="Zamknij" data-i18n-aria-label="common.close"></button>
+    </header>
+
+    <!-- MAIN CONTENT -->
+    <main class="window__main">
+        <form id="openViewForm" class="form-grid" novalidate>
+            <!-- URL -->
+            <div class="form-row">
+                <label id="openViewUrlLabel" for="openViewUrl" class="form-label" data-i18n="openView.url.label"></label>
+                <div>
+                    <input type="url" class="w-auto form-control" id="openViewUrl" name="url" required
+                           placeholder="https://example.com" inputmode="url" autocomplete="off"
+                           aria-describedby="openViewUrlHelp openViewUrlError" />
+                    <div class="invalid-feedback" id="openViewUrlError" data-i18n="openView.url.error"></div>
+                </div>
+            </div>
+
+            <!-- toggle: more... -->
+            <div class="more-toggle align-self-end">
+                <a class="link-secondary small" data-bs-toggle="collapse" href="#openViewMore" role="button"
+                   aria-expanded="false" aria-controls="openViewMore" id="openViewMoreToggle"></a>
+            </div>
+
+            <!-- section: more -->
+            <div class="collapse more-section" id="openViewMore">
+                <!-- ID -->
+                <div class="form-row">
+                    <label id="openViewId_label" for="openViewId" class="form-label" data-i18n="openView.id.label"></label>
+                    <div>
+                        <input type="text" class="w-auto form-control" id="openViewId" name="id"
+                               autocomplete="off"
+                               aria-describedby="openViewIdHelp openViewIdError" />
+                        <div class="invalid-feedback" id="openViewIdError"></div>
+                    </div>
+                </div>
+
+                <!-- wybór okienka (pane) -->
+                <div class="pane-choice">
+                    <label class="form-label" id="paneChoice_label"></label>
+                    <div>
+                        <!-- w tym okienku -->
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="paneChoice" id="paneChoice_current" value="current" checked />
+                            <label class="form-check-label" id="paneChoice_current_label" for="paneChoice_current"></label>
+                        </div>
+
+                        <!-- w okienku… (lista istniejących) -->
+                        <div class="form-check" id="paneExistingWrap">
+                            <input class="form-check-input" type="radio" name="paneChoice" id="paneChoice_existing" value="existing" disabled />
+                            <label class="form-check-label me-2" id="paneChoice_existing_label" for="paneChoice_existing"></label>
+                            <select class="form-select d-inline-block w-auto align-middle" id="paneExistingSelect" disabled aria-label="Pane select"></select>
+                            <div class="invalid-feedback" id="paneExistingError"></div>
+                        </div>
+
+                        <!-- w nowym okienku -->
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="paneChoice" id="paneChoice_new" value="new" />
+                            <label class="form-check-label me-2" id="paneChoice_new_label" for="paneChoice_new"></label>
+                            <input type="text" class="form-control d-inline-block w-auto align-middle"
+                                   id="paneNewName" disabled />
+                            <div class="invalid-feedback" id="paneNewNameError"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </main>
+
+    <!-- BUTTON BAR -->
+    <footer class="window__footer">
+        <button type="button" class="btn btn-secondary" id="btnCancel"></button>
+        <button type="submit" form="openViewForm" class="btn btn-primary" id="btnSubmit" disabled></button>
+    </footer>
+</div>
+
+<script src="../../assets/bootstrap.bundle.min.js"></script>
+<script type="module" src="./openView.js"></script>
+</body>
+</html>

--- a/src/renderer/openView.ts
+++ b/src/renderer/openView.ts
@@ -194,6 +194,7 @@ document.addEventListener('DOMContentLoaded', () => {
     void refreshPanes();
     wireLiveValidation();
     window.dialog.onShow(() => {
+      void setupTranslations();
       resetFormUi();
       void refreshPanes();
     });

--- a/src/renderer/openView.ts
+++ b/src/renderer/openView.ts
@@ -24,7 +24,7 @@ function applyFieldErrors(list: { fieldId: string }[]) {
   }
 }
 
-async function setupTranslations() {
+async function applyTranslations() {
   const t = await window.i18n.bundle();
 
   const translations: Record<string, DotPath<OpenViewWindowTranslations>> = {
@@ -189,14 +189,17 @@ async function refreshPanes() {
 
 document.addEventListener('DOMContentLoaded', () => {
   void (async () => {
-    await setupTranslations();
-
+    await applyTranslations();
     void refreshPanes();
     wireLiveValidation();
+
     window.dialog.onShow(() => {
-      void setupTranslations();
       resetFormUi();
       void refreshPanes();
+    });
+
+    window.i18n.onLanguageChanged(() => {
+      void applyTranslations();
     });
 
     setTimeout(() => {

--- a/src/renderer/openView.ts
+++ b/src/renderer/openView.ts
@@ -1,0 +1,229 @@
+import type { OpenViewWindowTranslations } from '../types/TranslationStrings.js';
+import { DotPath } from '../types/ConfigTypes.js';
+import { getTyped } from '../utils/object.js';
+import { OpenViewPaneChoice, PanesInfo } from '../types/OpenView.js';
+
+let panesCache: PanesInfo | undefined = undefined;
+
+function el<T extends HTMLElement = HTMLElement>(id: string) {
+  return document.getElementById(id) as T;
+}
+
+function clearErrors() {
+  ['openViewUrl', 'openViewId', 'paneExistingSelect', 'paneNewName'].forEach(
+    (id) => {
+      el(id).classList.remove('is-invalid');
+    },
+  );
+}
+
+function applyFieldErrors(list: { fieldId: string }[]) {
+  for (const e of list) {
+    el(e.fieldId).classList.add('is-invalid');
+  }
+}
+
+async function setupTranslations() {
+  const t = await window.i18n.bundle();
+
+  const translations: Record<string, DotPath<OpenViewWindowTranslations>> = {
+    docTitle: 'title',
+    openViewTitle: 'title',
+    openViewUrlLabel: 'url.label',
+    openViewUrlError: 'url.error',
+    openViewMoreToggle: 'more',
+    openViewId_label: 'id.label',
+    openViewIdError: 'id.error',
+    paneChoice_label: 'pane.title',
+    paneChoice_current_label: 'pane.current',
+    paneChoice_existing_label: 'pane.existing',
+    paneExistingError: 'pane.existingError',
+    paneChoice_new_label: 'pane.new',
+    paneNewNameError: 'pane.newError',
+    btnCancel: 'command.cancel',
+    btnSubmit: 'command.open',
+  };
+  for (const [id, translationKey] of Object.entries(translations)) {
+    const value = getTyped(t, `windows.openView.${translationKey}`) as unknown;
+    el(id).textContent = typeof value === 'string' ? value : '';
+  }
+
+  const placeholderTranslations: Record<
+    string,
+    DotPath<OpenViewWindowTranslations>
+  > = {
+    openViewId: 'id.placeholder',
+    paneNewName: 'pane.newPlaceholder',
+  };
+  for (const [id, translationKey] of Object.entries(placeholderTranslations)) {
+    const value = getTyped(t, `windows.openView.${translationKey}`) as unknown;
+    el<HTMLInputElement>(id).placeholder =
+      typeof value === 'string' ? value : '';
+  }
+}
+
+function setupPaneSection(info: PanesInfo) {
+  const wrap = document.getElementById('paneExistingWrap')!;
+  const rExist = document.getElementById(
+    'paneChoice_existing',
+  ) as HTMLInputElement;
+  const sel = document.getElementById(
+    'paneExistingSelect',
+  ) as HTMLSelectElement;
+  sel.innerHTML = '';
+  const others = info.panes.filter((p) => p !== info.current);
+  for (const name of others) {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    sel.appendChild(opt);
+  }
+  const hasMany = info.panes.length > 1;
+  wrap.style.display = hasMany ? '' : 'none';
+  rExist.disabled = !hasMany;
+  sel.disabled = !hasMany;
+
+  const rCurr = document.getElementById(
+    'paneChoice_current',
+  ) as HTMLInputElement;
+  const rNew = document.getElementById('paneChoice_new') as HTMLInputElement;
+  const newName = document.getElementById('paneNewName') as HTMLInputElement;
+  const toggle = () => {
+    sel.disabled = !(rExist.checked && hasMany);
+    newName.disabled = !rNew.checked;
+  };
+  [rCurr, rExist, rNew].forEach((r) => {
+    r.addEventListener('change', toggle);
+  });
+  toggle();
+}
+
+function collectCandidate() {
+  const url = el<HTMLInputElement>('openViewUrl').value;
+  const id = el<HTMLInputElement>('openViewId').value || undefined;
+
+  const rCurr = el<HTMLInputElement>('paneChoice_current');
+  const rExist = el<HTMLInputElement>('paneChoice_existing');
+  const sel = el<HTMLSelectElement>('paneExistingSelect');
+  const newNm = el<HTMLInputElement>('paneNewName');
+
+  return {
+    url,
+    id,
+    pane: {
+      paneChoice: rCurr.checked
+        ? OpenViewPaneChoice.CURRENT
+        : rExist.checked
+          ? OpenViewPaneChoice.EXISTING
+          : OpenViewPaneChoice.NEW,
+      paneExistingName: sel.disabled ? undefined : sel.value || undefined,
+      paneNewName: newNm.disabled ? undefined : newNm.value || undefined,
+    },
+  };
+}
+
+function validateForm(showErrors: boolean): boolean {
+  if (!panesCache) return false;
+
+  const candidate = collectCandidate();
+  const result = window.openView.validate(candidate, panesCache);
+
+  const submitBtn = el<HTMLButtonElement>('btnSubmit');
+
+  if (result.ok) {
+    clearErrors();
+    submitBtn.disabled = false;
+    return true;
+  } else {
+    if (showErrors) {
+      clearErrors();
+      applyFieldErrors(result.fieldErrors);
+    }
+    submitBtn.disabled = true;
+    return false;
+  }
+}
+
+function wireLiveValidation() {
+  const url = el<HTMLInputElement>('openViewUrl');
+  const id = el<HTMLInputElement>('openViewId');
+  const sel = el<HTMLSelectElement>('paneExistingSelect');
+  const newNm = el<HTMLInputElement>('paneNewName');
+  const rads = [
+    el<HTMLInputElement>('paneChoice_current'),
+    el<HTMLInputElement>('paneChoice_existing'),
+    el<HTMLInputElement>('paneChoice_new'),
+  ];
+
+  const softCheck = () => void validateForm(false);
+
+  url.addEventListener('input', softCheck);
+  id.addEventListener('input', softCheck);
+  sel.addEventListener('change', softCheck);
+  newNm.addEventListener('input', softCheck);
+  rads.forEach((r) => {
+    r.addEventListener('change', softCheck);
+  });
+
+  [url, id, sel, newNm, ...rads].forEach((elem) => {
+    elem.addEventListener('blur', () => void validateForm(true));
+  });
+}
+
+function resetFormUi() {
+  el<HTMLFormElement>('openViewForm').reset();
+  clearErrors();
+  el<HTMLButtonElement>('btnSubmit').disabled = true;
+}
+
+async function refreshPanes() {
+  panesCache = await window.openView.getPanes();
+
+  setupPaneSection(panesCache);
+  validateForm(false);
+  setTimeout(() => {
+    el<HTMLInputElement>('openViewUrl').focus();
+  }, 0);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  void (async () => {
+    await setupTranslations();
+
+    void refreshPanes();
+    wireLiveValidation();
+    window.dialog.onShow(() => {
+      resetFormUi();
+      void refreshPanes();
+    });
+
+    setTimeout(() => {
+      el<HTMLFormElement>('openViewUrl').focus();
+    }, 0);
+
+    const close = () => {
+      window.close();
+    };
+    el('btnClose').addEventListener('click', close);
+    el('btnCancel').addEventListener('click', close);
+    window.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') window.close();
+    });
+
+    const form = el<HTMLFormElement>('openViewForm');
+    form.addEventListener('submit', (ev) => {
+      ev.preventDefault();
+      clearErrors();
+
+      const result = window.openView.validate(collectCandidate(), panesCache!);
+
+      if (!result.ok) {
+        applyFieldErrors(result.fieldErrors);
+        return;
+      }
+
+      window.openView.openUrl(result.data);
+      window.close();
+    });
+  })();
+});

--- a/src/renderer/preferences.html
+++ b/src/renderer/preferences.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html lang="en" data-bs-theme="light">
+
 <head>
     <title id="docTitle"></title>
     <meta charset="utf-8" />
@@ -12,18 +13,17 @@
 </head>
 
 <body>
-<div class="window">
-<!-- TITLE BAR -->
-<header class="window__header">
-    <h1 class="window__title" id="title"></h1>
-    <button type="button" class="btn btn-close window__close" id="btnClose"
-            aria-label="Zamknij" data-i18n-aria-label="common.close"></button>
-</header>
+    <div class="window">
+        <!-- TITLE BAR -->
+        <header class="window__header">
+            <h1 class="window__title" id="title"></h1>
+            <button type="button" class="btn btn-close window__close" id="btnClose" aria-label="Zamknij"></button>
+        </header>
 
-<!-- MAIN CONTENT -->
-<main class="window__main container">
-    <div class="row justify-content-center">
-        <div class="col-12 col-md-10 col-lg-8">
+        <!-- MAIN CONTENT -->
+        <main class="window__main container">
+            <div class="row justify-content-center">
+                <div class="col-12 col-md-10 col-lg-8">
 
                     <div class="mb-3">
                         <div class="form-check form-switch">
@@ -47,18 +47,19 @@
                         </div>
                     </div>
                     <div class="hint mb-3" id="showInWindowListHint"></div>
-        </div>
+                </div>
+            </div>
+        </main>
+
+        <!-- BUTTON BAR -->
+        <footer class="window__footer">
+            <button id="btnCloseB" type="button" class="btn btn-primary">
+                ✕ <span id="closeBtnLabel"></span>
+            </button>
+        </footer>
     </div>
-</main>
 
-    <!-- BUTTON BAR -->
-    <footer class="window__footer">
-        <button id="btnCloseB" type="button" class="btn btn-primary">
-            ✕ <span id="closeBtnLabel"></span>
-        </button>
-    </footer>
-</div>
-
-<script type="module" src="./preferences.js"></script>
+    <script type="module" src="./preferences.js"></script>
 </body>
+
 </html>

--- a/src/renderer/preferences.html
+++ b/src/renderer/preferences.html
@@ -24,7 +24,6 @@
         <main class="window__main container">
             <div class="row justify-content-center">
                 <div class="col-12 col-md-10 col-lg-8">
-
                     <div class="mb-3">
                         <div class="form-check form-switch">
                             <input class="form-check-input" type="checkbox" role="switch" id="showWindowFrame">
@@ -47,7 +46,21 @@
                         </div>
                     </div>
                     <div class="hint mb-3" id="showInWindowListHint"></div>
+
+                    <hr class="my-4" />
+
+                    <div class="mb-3">
+                        <div class="d-flex align-items-center gap-3 flex-nowrap">
+                            <label class="form-label mb-0 flex-grow-1 text-truncate" for="languageSelect"
+                                id="languageLabel"></label>
+                            <select class="form-select flex-shrink-0" id="languageSelect" style="max-width: 150px;">
+                                <option value="en" id="languageOptionEn"></option>
+                                <option value="pl" id="languageOptionPl"></option>
+                            </select>
+                        </div>
+                    </div>
                 </div>
+
             </div>
         </main>
 

--- a/src/renderer/preferences.html
+++ b/src/renderer/preferences.html
@@ -1,43 +1,29 @@
 <!doctype html>
 <html lang="en" data-bs-theme="light">
 <head>
-    <meta charset="utf-8" />
     <title id="docTitle"></title>
-
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark">
 
-    <script>
-        (function () {
-            const mql = window.matchMedia('(prefers-color-scheme: dark)');
-            const apply = () => {
-                document.documentElement.setAttribute('data-bs-theme', mql.matches ? 'dark' : 'light');
-            };
-            apply();
-            if (typeof mql.addEventListener === 'function') {
-                mql.addEventListener('change', apply);
-            } else {
-                // Safari/legacy
-                mql.addListener(apply);
-            }
-        })();
-    </script>
-
-    <!-- Bootstrap 5.3 CSS -->
     <link href="../../assets/bootstrap.min.css" rel="stylesheet">
-    <style>
-        body { padding: 1rem; }
-        .hint { font-size: .875rem; color: var(--bs-secondary-color); }
-        .form-switch .form-check-input { width: 2.5em; height: 1.25em; }
-    </style>
+    <link href="../../assets/appWindows.css" rel="stylesheet">
+    <script type="module" src="../../assets/motif.js"></script>
 </head>
 
-<body class="bg-body-tertiary">
-<div class="container">
+<body>
+<div class="window">
+<!-- TITLE BAR -->
+<header class="window__header">
+    <h1 class="window__title" id="title"></h1>
+    <button type="button" class="btn btn-close window__close" id="btnClose"
+            aria-label="Zamknij" data-i18n-aria-label="common.close"></button>
+</header>
+
+<!-- MAIN CONTENT -->
+<main class="window__main container">
     <div class="row justify-content-center">
         <div class="col-12 col-md-10 col-lg-8">
-            <div class="card shadow-sm">
-                <div class="card-body">
-                    <h1 id="title" class="h5 mb-4"></h1>
 
                     <div class="mb-3">
                         <div class="form-check form-switch">
@@ -61,16 +47,16 @@
                         </div>
                     </div>
                     <div class="hint mb-3" id="showInWindowListHint"></div>
-                </div>
-
-                <div class="card-footer text-end">
-                    <button id="closeBtn" type="button" class="btn btn-danger btn-sm">
-                        ✕ <span id="closeBtnLabel"></span>
-                    </button>
-                </div>
-            </div>
         </div>
     </div>
+</main>
+
+    <!-- BUTTON BAR -->
+    <footer class="window__footer">
+        <button id="btnCloseB" type="button" class="btn btn-primary">
+            ✕ <span id="closeBtnLabel"></span>
+        </button>
+    </footer>
 </div>
 
 <script type="module" src="./preferences.js"></script>

--- a/src/renderer/preferences.ts
+++ b/src/renderer/preferences.ts
@@ -17,7 +17,6 @@ const translations: Record<string, keyof PreferencesWindowTranslations> = {
   languageOptionPl: 'polish',
 };
 
-const LANG_VALUES = Object.values(Lang) as Lang[];
 let currentLang: Lang | undefined;
 
 async function applyTranslations(): Promise<void> {
@@ -66,12 +65,9 @@ function setupEventListeners(): void {
 
   el<HTMLSelectElement>('languageSelect').addEventListener('change', (e) => {
     const lang = (e.target as HTMLSelectElement).value as Lang;
-    if (!LANG_VALUES.includes(lang)) return;
-    if (lang === currentLang) return;
+    if (!Object.values(Lang).includes(lang) || lang === currentLang) return;
 
-    currentLang = lang;
     window.preferences.set({ lang });
-    void applyTranslations();
   });
 
   const close = () => {
@@ -98,6 +94,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     window.dialog.onShow(() => {
       void refreshPreferencesWindow();
+    });
+
+    window.i18n.onLanguageChanged((lang) => {
+      currentLang = lang;
+      el<HTMLSelectElement>('languageSelect').value = lang;
+      void applyTranslations();
     });
   })();
 });

--- a/src/renderer/preferences.ts
+++ b/src/renderer/preferences.ts
@@ -1,18 +1,16 @@
 import type { PreferencesWindowTranslations } from '../types/TranslationStrings.js';
 import { getTyped } from '../utils/object.js';
-
-const qs = <T extends Element>(selector: string): T =>
-  document.querySelector(selector)!;
+import { el } from '../utils/dom.js';
 
 const translations: Record<string, keyof PreferencesWindowTranslations> = {
-  '#docTitle': 'title',
-  '#title': 'title',
-  '#showInWindowListLabel': 'showInWindowList',
-  '#showWindowFrameLabel': 'showWindowFrame',
-  '#showWindowFrameHint': 'windowReloadNeededHint',
-  '#showInWindowListHint': 'windowReloadNeededHint',
-  '#showAppMenuLabel': 'showAppMenu',
-  '#closeBtnLabel': 'close',
+  'docTitle': 'title',
+  'title': 'title',
+  'showInWindowListLabel': 'showInWindowList',
+  'showWindowFrameLabel': 'showWindowFrame',
+  'showWindowFrameHint': 'windowReloadNeededHint',
+  'showInWindowListHint': 'windowReloadNeededHint',
+  'showAppMenuLabel': 'showAppMenu',
+  'closeBtnLabel': 'close',
 };
 
 async function main() {
@@ -23,30 +21,30 @@ async function main() {
       t,
       `windows.preferences.${translationKey}`,
     ) as unknown;
-    qs(id).textContent = typeof value === 'string' ? value : '';
+    el(id).textContent = typeof value === 'string' ? value : '';
   }
 
-  qs<HTMLDivElement>('#showInWindowListHint').hidden =
+  el<HTMLDivElement>('showInWindowListHint').hidden =
     window.preferences.info.platform !== 'linux';
 
   const prefs = await window.preferences.get();
-  qs<HTMLInputElement>('#showInWindowList').checked = prefs.showInWindowList;
-  qs<HTMLInputElement>('#showWindowFrame').checked = prefs.showWindowFrame;
-  qs<HTMLInputElement>('#showAppMenu').checked = prefs.showAppMenu;
+  el<HTMLInputElement>('showInWindowList').checked = prefs.showInWindowList;
+  el<HTMLInputElement>('showWindowFrame').checked = prefs.showWindowFrame;
+  el<HTMLInputElement>('showAppMenu').checked = prefs.showAppMenu;
 
-  qs('#showInWindowList').addEventListener('change', (e) => {
+  el('showInWindowList').addEventListener('change', (e) => {
     window.preferences.set({
       showInWindowList: (e.target as HTMLInputElement).checked,
     });
   });
 
-  qs('#showWindowFrame').addEventListener('change', (e) => {
+  el('showWindowFrame').addEventListener('change', (e) => {
     window.preferences.set({
       showWindowFrame: (e.target as HTMLInputElement).checked,
     });
   });
 
-  qs('#showAppMenu').addEventListener('change', (e) => {
+  el('showAppMenu').addEventListener('change', (e) => {
     window.preferences.set({
       showAppMenu: (e.target as HTMLInputElement).checked,
     });
@@ -55,12 +53,12 @@ async function main() {
   const close = () => {
     window.close();
   };
-  qs('#btnClose').addEventListener('click', close);
-  qs('#btnCloseB').addEventListener('click', close);
+  el('btnClose').addEventListener('click', close);
+  el('btnCloseB').addEventListener('click', close);
   window.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') window.close();
   });
 }
 
 void main().catch(console.error);
-export {};
+export { };

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -41,7 +41,16 @@ export const translations: TranslationStrings = {
       title: 'About',
     },
     newPane: {
-      name: 'Name',
+      title: 'New pane',
+      id: {
+        label: 'ID',
+        placeholder: 'eg. example.com',
+        error: 'Invalid ID',
+      },
+      command: {
+        cancel: 'Cancel',
+        open: 'Open',
+      },
     },
     openView: {
       title: 'Open view',
@@ -84,14 +93,19 @@ export const translations: TranslationStrings = {
     switcher: {
       hint: 'Hold Ctrl, press Tab / Shift+Tab. Release Ctrl to select.',
     },
-    moveViewToPane: {
-      title: 'Move page to pane',
-      existing: 'in existing pane…',
-      existingHelp: 'Available if more than one pane exists.',
-      existingError: 'Choose one from the list',
-      new: 'in a new pane',
-      newPlaceholder: 'work',
-      newError: 'Enter the name for a new pane',
+    moveView: {
+      title: 'Move view',
+      pane: {
+        existing: 'to the existing pane:',
+        existingError: 'Choose one from the list',
+        new: 'to a new pane',
+        newPlaceholder: 'eg. work',
+        newError: 'Enter the name for a new pane',
+      },
+      command: {
+        cancel: 'Cancel',
+        open: 'Open',
+      },
     },
   },
 };

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1,4 +1,6 @@
-export default {
+import { TranslationStrings } from '../types/TranslationStrings.js';
+
+export const translations: TranslationStrings = {
   error: {
     error: 'Error',
     unknown: 'Unknown Error',
@@ -9,30 +11,65 @@ export default {
     },
   },
   menu: {
-    app: 'Application',
     backward: 'Back',
     closeView: 'Close the web page',
     closePane: 'Close the pane',
-    english: 'English',
     forceReload: 'Force Reload',
     forward: 'Forward',
-    language: 'Language',
     minimize: 'Minimize',
-    navigation: 'Navigation',
-    nextView: 'Next View',
-    polish: 'Polish',
     preferences: 'Preferences',
-    previousView: 'Previous View',
     quit: 'Quit',
     reload: 'Reload',
     resetZoom: 'Reset Zoom',
-    toggleDevTools: 'Toggle Developer Tools',
-    toggleFullscreen: 'Toggle Fullscreen',
     view: 'View',
     zoomIn: 'Zoom In',
     zoomOut: 'Zoom Out',
+    pane: 'Pane',
+    newPane: 'New pane',
+    switchPane: 'Switch pane',
+    minimizeAll: 'Minimize all',
+    page: 'Page',
+    openView: 'Open page',
+    switchView: 'Switch page',
+    moveViewToPane: 'Move page to pane',
+    help: 'Help',
+    instruction: 'Instruction',
+    about: 'About',
   },
   windows: {
+    about: {
+      title: 'About',
+    },
+    newPane: {
+      name: 'Name',
+    },
+    openView: {
+      title: 'Open view',
+      url: {
+        label: 'URL',
+        placeholder: 'https://example.com',
+        error: 'Invalid URL',
+      },
+      more: 'more...',
+      id: {
+        label: 'ID',
+        placeholder: 'eg. example.com',
+        error: 'Invalid ID',
+      },
+      pane: {
+        title: 'Target pane',
+        current: 'this pane',
+        existing: 'in existing pane:',
+        existingError: 'Choose one from the list',
+        new: 'in a new pane',
+        newPlaceholder: 'eg. work',
+        newError: 'Enter the name for a new pane',
+      },
+      command: {
+        cancel: 'Cancel',
+        open: 'Open',
+      },
+    },
     preferences: {
       title: 'Preferences',
       showAppMenu: 'Show application menu',
@@ -40,9 +77,21 @@ export default {
       windowReloadNeededHint: 'Changing this will briefly recreate panes.',
       showInWindowList: 'Show in window list',
       close: 'Close',
+      language: 'Language',
+      polish: 'Polish',
+      english: 'English',
     },
     switcher: {
       hint: 'Hold Ctrl, press Tab / Shift+Tab. Release Ctrl to select.',
+    },
+    moveViewToPane: {
+      title: 'Move page to pane',
+      existing: 'in existing pane…',
+      existingHelp: 'Available if more than one pane exists.',
+      existingError: 'Choose one from the list',
+      new: 'in a new pane',
+      newPlaceholder: 'work',
+      newError: 'Enter the name for a new pane',
     },
   },
 };

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -38,7 +38,15 @@ export const translations: TranslationStrings = {
   },
   windows: {
     about: {
-      title: 'About',
+      title: 'About the application',
+      name: 'Name',
+      version: 'Version',
+      author: 'Author',
+      license: 'License',
+      homepage: 'Homepage',
+      repository: 'Repository',
+      bugs: 'Bug reports',
+      close: 'Close',
     },
     newPane: {
       title: 'New pane',

--- a/src/translations/pl.ts
+++ b/src/translations/pl.ts
@@ -38,7 +38,15 @@ export const translations: TranslationStrings = {
   },
   windows: {
     about: {
-      title: 'O Web-pane',
+      title: 'O aplikacji',
+      name: 'Nazwa',
+      version: 'Wersja',
+      author: 'Autor',
+      license: 'Licencja',
+      homepage: 'Strona projektu',
+      repository: 'Repozytorium',
+      bugs: 'Zgłoszenia błędów',
+      close: 'Zamknij',
     },
     newPane: {
       title: 'Nowe okienko',

--- a/src/translations/pl.ts
+++ b/src/translations/pl.ts
@@ -1,4 +1,6 @@
-export default {
+import { TranslationStrings } from '../types/TranslationStrings.js';
+
+export const translations: TranslationStrings = {
   error: {
     error: 'Błąd',
     unknown: 'Nieznany błąd',
@@ -9,30 +11,65 @@ export default {
     },
   },
   menu: {
-    app: 'Aplikacja',
     backward: 'Wstecz',
     closeView: 'Zamknij stronę',
-    closePane: 'Zamknij okno',
-    english: 'Angielski',
+    closePane: 'Zamknij okienko',
     forceReload: 'Wymuś przeładowanie',
     forward: 'Dalej',
-    language: 'Język',
     minimize: 'Minimalizuj',
-    navigation: 'Nawigacja',
-    nextView: 'Następny widok',
-    polish: 'Polski',
     preferences: 'Preferencje',
-    previousView: 'Poprzedni widok',
     quit: 'Zakończ',
     reload: 'Przeładuj',
     resetZoom: 'Zresetuj powiększenie',
-    toggleDevTools: 'Pokaż narzędzia deweloperskie',
-    toggleFullscreen: 'Pełny ekran',
     view: 'Widok',
     zoomIn: 'Powiększ',
     zoomOut: 'Pomniejsz',
+    pane: 'Okienko',
+    newPane: 'Nowe okienko',
+    switchPane: 'Przełącz okienko',
+    minimizeAll: 'Zminimalizuj wszystkie',
+    page: 'Strona',
+    openView: 'Otwórz stronę',
+    switchView: 'Przełącz stronę',
+    moveViewToPane: 'Przenieś do okienka...',
+    help: 'Pomoc',
+    instruction: 'Instrukcja',
+    about: 'O Web-pane',
   },
   windows: {
+    about: {
+      title: 'O Web-pane',
+    },
+    newPane: {
+      name: 'Nazwa',
+    },
+    openView: {
+      title: 'Otwórz widok',
+      url: {
+        label: 'Adres URL',
+        placeholder: 'https://example.com',
+        error: 'Nieprawidłowy adres URL.',
+      },
+      more: 'więcej...',
+      id: {
+        label: 'ID',
+        placeholder: 'np. example-com',
+        error: 'Nieprawidłowe ID.',
+      },
+      pane: {
+        title: 'Gdzie otworzyć?',
+        current: 'w tym okienku',
+        existing: 'w okienku:',
+        existingError: 'Wybierz okienko z listy.',
+        new: 'w nowym okienku',
+        newPlaceholder: 'np. praca',
+        newError: 'Podaj nazwę nowego okienka.',
+      },
+      command: {
+        cancel: 'Anuluj',
+        open: 'Otwórz',
+      },
+    },
     preferences: {
       title: 'Preferencje',
       showAppMenu: 'Pokaż menu aplikacji',
@@ -40,9 +77,21 @@ export default {
       windowReloadNeededHint: 'Zmiana tej opcji spowoduje odtworzenie okien.',
       showInWindowList: 'Pokaż na liście okien',
       close: 'Zamknij',
+      language: 'Język',
+      polish: 'Polski',
+      english: 'Angielski',
     },
     switcher: {
       hint: 'Trzymaj Ctrl, naciskaj Tab / Shift+Tab. Puść Ctrl, aby wybrać.',
+    },
+    moveViewToPane: {
+      title: 'Przenieś stronę do okienka',
+      existing: 'w okienku…',
+      existingHelp: 'Dostępne, jeśli otwartych jest więcej niż jedno okno.',
+      existingError: 'Wybierz okienko z listy.',
+      new: 'w nowym okienku',
+      newPlaceholder: 'np. praca',
+      newError: 'Podaj nazwę nowego okienka.',
     },
   },
 };

--- a/src/translations/pl.ts
+++ b/src/translations/pl.ts
@@ -41,7 +41,16 @@ export const translations: TranslationStrings = {
       title: 'O Web-pane',
     },
     newPane: {
-      name: 'Nazwa',
+      title: 'Nowe okienko',
+      id: {
+        label: 'ID',
+        placeholder: 'np. example-com',
+        error: 'Nieprawidłowe ID.',
+      },
+      command: {
+        cancel: 'Anuluj',
+        open: 'Otwórz',
+      },
     },
     openView: {
       title: 'Otwórz widok',
@@ -84,14 +93,19 @@ export const translations: TranslationStrings = {
     switcher: {
       hint: 'Trzymaj Ctrl, naciskaj Tab / Shift+Tab. Puść Ctrl, aby wybrać.',
     },
-    moveViewToPane: {
-      title: 'Przenieś stronę do okienka',
-      existing: 'w okienku…',
-      existingHelp: 'Dostępne, jeśli otwartych jest więcej niż jedno okno.',
-      existingError: 'Wybierz okienko z listy.',
-      new: 'w nowym okienku',
-      newPlaceholder: 'np. praca',
-      newError: 'Podaj nazwę nowego okienka.',
+    moveView: {
+      title: 'Przenieś widok',
+      pane: {
+        existing: 'do okienka:',
+        existingError: 'Wybierz okienko z listy.',
+        new: 'do nowego okienka',
+        newPlaceholder: 'np. praca',
+        newError: 'Podaj nazwę nowego okienka.',
+      },
+      command: {
+        cancel: 'Anuluj',
+        open: 'Otwórz',
+      },
     },
   },
 };

--- a/src/types/AppConfig.ts
+++ b/src/types/AppConfig.ts
@@ -2,12 +2,12 @@ import type { Lang } from './Lang.js';
 import type { PaneState } from './PaneState.js';
 
 export interface AppConfig {
-  lang: Lang;
   panes: Record<string, PaneState> & { main: PaneState };
   ui: AppUiConfig;
 }
 
 export interface AppUiConfig {
+  lang: Lang;
   showWindowFrame: boolean;
   showAppMenu: boolean;
   showInWindowList: boolean;

--- a/src/types/ConfigZodSchema.ts
+++ b/src/types/ConfigZodSchema.ts
@@ -11,9 +11,9 @@ const WindowSchema = z.object({
 });
 
 export const ConfigZodSchema = z.object({
-  lang: z.enum(Lang),
   panes: z.object({ main: WindowSchema }).catchall(WindowSchema),
   ui: z.object({
+    lang: z.enum(Lang),
     showWindowFrame: z.boolean(),
     showAppMenu: z.boolean(),
     showInWindowList: z.boolean(),

--- a/src/types/MoveView.ts
+++ b/src/types/MoveView.ts
@@ -1,0 +1,8 @@
+export enum MoveViewPaneChoice {
+  EXISTING = 'existing',
+  NEW = 'new',
+}
+
+export interface MoveViewPayload {
+  toPaneId: string;
+}

--- a/src/types/OpenView.ts
+++ b/src/types/OpenView.ts
@@ -9,8 +9,3 @@ export interface OpenViewPayload {
   id: string;
   paneName: string;
 }
-
-export interface PanesInfo {
-  current: string;
-  panes: string[];
-}

--- a/src/types/OpenView.ts
+++ b/src/types/OpenView.ts
@@ -1,0 +1,16 @@
+export enum OpenViewPaneChoice {
+  CURRENT = 'current',
+  EXISTING = 'existing',
+  NEW = 'new',
+}
+
+export interface OpenViewPayload {
+  url: string;
+  id: string;
+  paneName: string;
+}
+
+export interface PanesInfo {
+  current: string;
+  panes: string[];
+}

--- a/src/types/PanesInfo.ts
+++ b/src/types/PanesInfo.ts
@@ -1,0 +1,4 @@
+export interface PanesInfo {
+  current: string;
+  panes: string[];
+}

--- a/src/types/TranslationStrings.ts
+++ b/src/types/TranslationStrings.ts
@@ -2,6 +2,10 @@ export interface TranslationStrings {
   error: ErrorTranslations;
   menu: MenuTranslations;
   windows: {
+    about: AboutWindowTranslations;
+    moveViewToPane: MoveViewToPaneWindowTranslations;
+    newPane: NewPaneWindowTranslations;
+    openView: OpenViewWindowTranslations;
     preferences: PreferencesWindowTranslations;
     switcher: {
       hint: string;
@@ -20,32 +24,90 @@ export interface ErrorTranslations {
 }
 
 export interface MenuTranslations {
-  backward: string;
-  closeView: string;
-  closePane: string;
-  english: string;
-  app: string;
-  forceReload: string;
-  forward: string;
-  language: string;
+  // Menu Pane
+  pane: string;
   minimize: string;
-  navigation: string;
-  nextView: string;
-  polish: string;
+  newPane: string;
+  switchPane: string;
+  closePane: string;
   preferences: string;
-  previousView: string;
+  minimizeAll: string;
   quit: string;
-  reload: string;
-  resetZoom: string;
-  toggleDevTools: string;
-  toggleFullscreen: string;
+
+  // Menu Page
+  page: string;
+  openView: string;
+  switchView: string;
+  moveViewToPane: string;
+  backward: string;
+  forward: string;
+  closeView: string;
+
+  // Menu View
   view: string;
+  reload: string;
+  forceReload: string;
   zoomIn: string;
   zoomOut: string;
+  resetZoom: string;
+
+  // Menu Help
+  help: string;
+  instruction: string;
+  about: string;
+}
+
+export interface AboutWindowTranslations {
+  title: string;
+}
+
+export interface MoveViewToPaneWindowTranslations {
+  title: string;
+  existing: string;
+  existingHelp: string;
+  existingError: string;
+  new: string;
+  newPlaceholder: string;
+  newError: string;
+}
+
+export interface NewPaneWindowTranslations {
+  name: string;
+}
+
+export interface OpenViewWindowTranslations {
+  title: string;
+  url: {
+    label: string;
+    placeholder: string;
+    error: string;
+  };
+  more: string;
+  id: {
+    label: string;
+    placeholder: string;
+    error: string;
+  };
+  pane: {
+    title: string;
+    current: string;
+    existing: string;
+    existingError: string;
+    new: string;
+    newPlaceholder: string;
+    newError: string;
+  };
+  command: {
+    open: string;
+    cancel: string;
+  };
 }
 
 export interface PreferencesWindowTranslations {
   title: string;
+  language: string;
+  polish: string;
+  english: string;
   showAppMenu: string;
   showWindowFrame: string;
   windowReloadNeededHint: string;

--- a/src/types/TranslationStrings.ts
+++ b/src/types/TranslationStrings.ts
@@ -59,6 +59,14 @@ export interface MenuTranslations {
 
 export interface AboutWindowTranslations {
   title: string;
+  name: string;
+  version: string;
+  author: string;
+  license: string;
+  homepage: string;
+  repository: string;
+  bugs: string;
+  close: string;
 }
 
 export interface MoveViewWindowTranslations {

--- a/src/types/TranslationStrings.ts
+++ b/src/types/TranslationStrings.ts
@@ -3,7 +3,7 @@ export interface TranslationStrings {
   menu: MenuTranslations;
   windows: {
     about: AboutWindowTranslations;
-    moveViewToPane: MoveViewToPaneWindowTranslations;
+    moveView: MoveViewWindowTranslations;
     newPane: NewPaneWindowTranslations;
     openView: OpenViewWindowTranslations;
     preferences: PreferencesWindowTranslations;
@@ -61,18 +61,32 @@ export interface AboutWindowTranslations {
   title: string;
 }
 
-export interface MoveViewToPaneWindowTranslations {
+export interface MoveViewWindowTranslations {
   title: string;
-  existing: string;
-  existingHelp: string;
-  existingError: string;
-  new: string;
-  newPlaceholder: string;
-  newError: string;
+  pane: {
+    existing: string;
+    existingError: string;
+    new: string;
+    newPlaceholder: string;
+    newError: string;
+  };
+  command: {
+    open: string;
+    cancel: string;
+  };
 }
 
 export interface NewPaneWindowTranslations {
-  name: string;
+  title: string;
+  id: {
+    label: string;
+    placeholder: string;
+    error: string;
+  };
+  command: {
+    open: string;
+    cancel: string;
+  };
 }
 
 export interface OpenViewWindowTranslations {

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -1,0 +1,8 @@
+export type ValidationResult<Payload> =
+  | { ok: true; data: Payload }
+  | { ok: false; fieldErrors: ValidationError[] };
+
+export interface ValidationError {
+  fieldId: string;
+  message: string;
+}

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -1,0 +1,51 @@
+import type { AppUiConfig } from './AppConfig.js';
+import { Lang } from './Lang.js';
+import { PathValue } from './ConfigTypes.js';
+import { OpenViewPayload, PanesInfo } from './OpenView.js';
+import { TranslationStrings } from './TranslationStrings.js';
+
+declare global {
+  interface Window {
+    dialog: DialogAPI;
+    i18n: I18nAPI;
+    openView: OpenViewAPI;
+    preferences: PreferencesAPI;
+    switcher: SwitcherAPI;
+  }
+}
+
+export interface DialogAPI {
+  onShow: (cb: () => void) => () => void;
+}
+
+export interface I18nAPI {
+  t<P extends string>(key: P, lang?: Lang): PathValue<TranslationStrings, P>;
+  bundle(lang?: Lang): Promise<TranslationStrings>;
+}
+
+export interface OpenViewAPI {
+  getPanes: () => Promise<PanesInfo>;
+  openUrl: (payload: OpenViewPayload) => void;
+  validate: (
+    candidate: {
+      url: string;
+      id: string | undefined;
+      pane: {
+        paneChoice: string;
+        paneExistingName: string | undefined;
+        paneNewName: string | undefined;
+      };
+    },
+    panesInfo: { current: string; panes: string[] },
+  ) =>
+    | { ok: true; data: OpenViewPayload }
+    | { ok: false; fieldErrors: { fieldId: string; messageKey: string }[] };
+}
+
+export interface PreferencesAPI {
+  get(): Promise<AppUiConfig>;
+  set(patch: Partial<AppUiConfig>): void;
+  info: {
+    platform: NodeJS.Platform;
+  };
+}

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -9,6 +9,7 @@ import { MoveViewPayload } from './MoveView.js';
 
 declare global {
   interface Window {
+    about: AboutAPI;
     dialog: DialogAPI;
     i18n: I18nAPI;
     moveView: MoveViewAPI;
@@ -17,6 +18,10 @@ declare global {
     preferences: PreferencesAPI;
     switcher: SwitcherAPI;
   }
+}
+
+export interface AboutAPI {
+  getInfo: () => Promise<AboutInfo>;
 }
 
 export interface DialogAPI {

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -22,6 +22,7 @@ declare global {
 
 export interface AboutAPI {
   getInfo: () => Promise<AboutInfo>;
+  openExternal: (url: string) => void;
 }
 
 export interface DialogAPI {

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -1,13 +1,18 @@
 import type { AppUiConfig } from './AppConfig.js';
 import { Lang } from './Lang.js';
 import { PathValue } from './ConfigTypes.js';
-import { OpenViewPayload, PanesInfo } from './OpenView.js';
+import { OpenViewPayload } from './OpenView.js';
 import { TranslationStrings } from './TranslationStrings.js';
+import { PanesInfo } from './PanesInfo.js';
+import { ValidationResult } from './validation.js';
+import { MoveViewPayload } from './MoveView.js';
 
 declare global {
   interface Window {
     dialog: DialogAPI;
     i18n: I18nAPI;
+    moveView: MoveViewAPI;
+    newPane: NewPaneAPI;
     openView: OpenViewAPI;
     preferences: PreferencesAPI;
     switcher: SwitcherAPI;
@@ -23,6 +28,28 @@ export interface I18nAPI {
   bundle(lang?: Lang): Promise<TranslationStrings>;
 }
 
+export interface MoveViewAPI {
+  getPanes: () => Promise<PanesInfo>;
+  doMoveView: (toPaneId: string) => void;
+  validate: (
+    candidate: MoveViewPayload,
+    panesInfo: PanesInfo,
+  ) => ValidationResult<MoveViewPayload>;
+}
+
+export interface NewPaneAPI {
+  createPane: (id: string) => void;
+  getPanes: () => Promise<string[]>;
+  validate: (
+    candidate: {
+      id: string | undefined;
+    },
+    panes: string[],
+  ) =>
+    | { ok: true; data: { id: string } }
+    | { ok: false; fieldErrors: { fieldId: string; messageKey: string }[] };
+}
+
 export interface OpenViewAPI {
   getPanes: () => Promise<PanesInfo>;
   openUrl: (payload: OpenViewPayload) => void;
@@ -36,7 +63,7 @@ export interface OpenViewAPI {
         paneNewName: string | undefined;
       };
     },
-    panesInfo: { current: string; panes: string[] },
+    panesInfo: PanesInfo,
   ) =>
     | { ok: true; data: OpenViewPayload }
     | { ok: false; fieldErrors: { fieldId: string; messageKey: string }[] };

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -30,6 +30,7 @@ export interface DialogAPI {
 }
 
 export interface I18nAPI {
+  onLanguageChanged: (cb: (lang: Lang) => void) => () => void;
   t<P extends string>(key: P, lang?: Lang): PathValue<TranslationStrings, P>;
   bundle(lang?: Lang): Promise<TranslationStrings>;
 }

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,0 +1,3 @@
+export function el<T extends HTMLElement = HTMLElement>(id: string) {
+  return document.getElementById(id) as T;
+}

--- a/src/utils/makeId.ts
+++ b/src/utils/makeId.ts
@@ -1,0 +1,5 @@
+export function makeId(url: string) {
+  const u = new URL(url);
+
+  return u.hostname;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,7 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": ["src", "test"],
+  "include": ["src", "test", "src/types/**/*.d.ts"],
   "exclude": ["node_modules", "src/preload/**/*.ts"],
   "ts-node": {
     "transpileOnly": true,


### PR DESCRIPTION
Introduces several ways to manage panes and views of web pages by providing the menu items, keyboard shortcuts and a dialogs for:

- New Pane - opens empty pane
- Open Page - opens a new view of web page in current, other existing or a new pane
- Move Page - moves an already opened view to other pane - either existing one or a new one

Also a set of improvements were made:
- a new Help > About window with links to the repository, bugs page and instructions for the app
- the language selection was moved to the Preferences window
- the change of language affects all the windows and the menu immediately
- the app is properly licensed now
- README.md is updated to current workflow